### PR TITLE
Add Windows build to workflow

### DIFF
--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:  
 
 jobs:
-  build-and-upload-mac:
+  build-mac:
     name: Build for Mac
     runs-on: macos-latest
     steps:
@@ -44,7 +44,7 @@ jobs:
           name: wheels
           path: dist
 
-  build-and-upload-linux:
+  build-linux:
     name: Build for Linux
     runs-on: ubuntu-latest
     strategy:
@@ -69,7 +69,36 @@ jobs:
         pip install rustsim --no-index --find-links dist --force-reinstall
         pip install pytest
         # pytest
-    - name: Upload wheels
+    - name: Upload wheels for Linux
+      uses: actions/upload-artifact@v3
+      with:
+        name: wheels
+        path: dist
+
+  build-windows:
+    name: Build for Windows
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        target: [x86_64]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+        architecture: x64
+    - name: Build wheels for Windows
+      uses: PyO3/maturin-action@v1
+      with:
+        rust-toolchain: stable
+        target: ${{ matrix.target }}
+        args: --release --out dist -i 3.7 3.8 3.9 '3.10'
+    - name: Install built wheel
+      if: matrix.target == 'x86_64'
+      run: |
+        pip install rustsim --no-index --find-links dist --force-reinstall
+        pip install pytest
+    - name: Upload wheels for Windows
       uses: actions/upload-artifact@v3
       with:
         name: wheels
@@ -78,7 +107,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [ build-and-upload-mac, build-and-upload-linux ]
+    needs: [ build-mac, build-linux, build-windows ]
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
       - run: echo 'Releasing to PyPi because this is a push to main.'


### PR DESCRIPTION
OAK expects a Windows wheel for tests during its workflow, so we shall provide.
See https://github.com/INCATools/ontology-access-kit/pull/451 for example.