### PR TITLE
Convert `String` object to `&str` - Second attempt.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,8 @@ impl RustSemsimian {
 
     pub fn jaccard_similarity(
         &mut self,
-        term1: &TermID,
-        term2: &TermID,
+        term1: &str,
+        term2: &str,
         predicates: &Option<HashSet<Predicate>>,
     ) -> f64 {
         let (this_closure_map, _) = self.get_closure_and_ic_map(predicates);
@@ -49,8 +49,8 @@ impl RustSemsimian {
 
     pub fn resnik_similarity(
         &self,
-        term1: &TermID,
-        term2: &TermID,
+        term1: &str,
+        term2: &str,
         predicates: &Option<HashSet<Predicate>>,
     ) -> f64 {
         calculate_max_information_content(&self.closure_map, &self.ic_map, term1, term2, predicates)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,7 @@
-use std::{
-    collections::{HashMap, HashSet},
-};
 use pyo3::prelude::*;
-pub mod utils;
+use std::collections::{HashMap, HashSet};
 pub mod similarity;
+pub mod utils;
 
 use similarity::{calculate_max_information_content, calculate_phenomizer_score};
 use utils::{convert_list_of_tuples_to_hashmap, expand_term_using_closure, predicate_set_to_key};
@@ -17,7 +15,6 @@ pub struct RustSemsimian {
 
     ic_map: HashMap<PredicateSetKey, HashMap<TermID, f64>>,
     // ic_map is something like {('is_a_+_part_of'), {'GO:1234': 1.234}}
-
     closure_map: HashMap<PredicateSetKey, HashMap<TermID, HashSet<TermID>>>,
     // closure_map is something like {('is_a_+_part_of'), {'GO:1234': {'GO:1234', 'GO:5678'}}}
 }
@@ -27,7 +24,6 @@ impl RustSemsimian {
     // TODO: also, we should support loading 'custom' ic
     // TODO: also also, we should use str's instead of String
     pub fn new(spo: Vec<(TermID, Predicate, TermID)>) -> RustSemsimian {
-
         RustSemsimian {
             spo,
             ic_map: HashMap::new(),
@@ -35,7 +31,12 @@ impl RustSemsimian {
         }
     }
 
-    pub fn jaccard_similarity(&mut self, term1: &TermID, term2: &TermID, predicates: &Option<HashSet<Predicate>>) -> f64 {
+    pub fn jaccard_similarity(
+        &mut self,
+        term1: &TermID,
+        term2: &TermID,
+        predicates: &Option<HashSet<Predicate>>,
+    ) -> f64 {
         let (this_closure_map, _) = self.get_closure_and_ic_map(predicates);
 
         let term1_set = expand_term_using_closure(term1, &this_closure_map, predicates);
@@ -46,7 +47,12 @@ impl RustSemsimian {
         intersection / union
     }
 
-    pub fn resnik_similarity(&self, term1: &TermID, term2: &TermID, predicates: &Option<HashSet<Predicate>>) -> f64 {
+    pub fn resnik_similarity(
+        &self,
+        term1: &TermID,
+        term2: &TermID,
+        predicates: &Option<HashSet<Predicate>>,
+    ) -> f64 {
         calculate_max_information_content(&self.closure_map, &self.ic_map, term1, term2, predicates)
     }
 
@@ -60,13 +66,27 @@ impl RustSemsimian {
     }
 
     // get closure and ic map for a given set of predicates. if the closure and ic map for the given predicates doesn't exist, create them
-    fn get_closure_and_ic_map(&mut self, predicates: &Option<HashSet<Predicate>>) ->
-            (HashMap<PredicateSetKey, HashMap<TermID, HashSet<TermID>>>, HashMap<PredicateSetKey, HashMap<TermID, f64>>) {
+    fn get_closure_and_ic_map(
+        &mut self,
+        predicates: &Option<HashSet<Predicate>>,
+    ) -> (
+        HashMap<PredicateSetKey, HashMap<TermID, HashSet<TermID>>>,
+        HashMap<PredicateSetKey, HashMap<TermID, f64>>,
+    ) {
         let predicate_set_key = predicate_set_to_key(&predicates);
-        if !self.closure_map.contains_key(&predicate_set_key) || !self.ic_map.contains_key(&predicate_set_key) {
-            let (this_closure_map, this_ic_map) = convert_list_of_tuples_to_hashmap(&self.spo, &predicates);
-            self.closure_map.insert(predicate_set_key.clone(), this_closure_map.get(&predicate_set_key).unwrap().clone());
-            self.ic_map.insert(predicate_set_key.clone(), this_ic_map.get(&predicate_set_key).unwrap().clone());
+        if !self.closure_map.contains_key(&predicate_set_key)
+            || !self.ic_map.contains_key(&predicate_set_key)
+        {
+            let (this_closure_map, this_ic_map) =
+                convert_list_of_tuples_to_hashmap(&self.spo, &predicates);
+            self.closure_map.insert(
+                predicate_set_key.clone(),
+                this_closure_map.get(&predicate_set_key).unwrap().clone(),
+            );
+            self.ic_map.insert(
+                predicate_set_key.clone(),
+                this_ic_map.get(&predicate_set_key).unwrap().clone(),
+            );
         }
         (self.closure_map.clone(), self.ic_map.clone())
     }
@@ -85,14 +105,23 @@ impl Semsimian {
         Ok(Semsimian { ss })
     }
 
-    fn jaccard_similarity(&mut self, term1: TermID, term2: TermID, predicates: Option<HashSet<Predicate>>) -> PyResult<f64> {
+    fn jaccard_similarity(
+        &mut self,
+        term1: TermID,
+        term2: TermID,
+        predicates: Option<HashSet<Predicate>>,
+    ) -> PyResult<f64> {
         Ok(self.ss.jaccard_similarity(&term1, &term2, &predicates))
     }
 
-    fn resnik_similarity(&mut self, term1: TermID, term2: TermID, predicates: Option<HashSet<Predicate>>) -> PyResult<f64> {
+    fn resnik_similarity(
+        &mut self,
+        term1: TermID,
+        term2: TermID,
+        predicates: Option<HashSet<Predicate>>,
+    ) -> PyResult<f64> {
         Ok(self.ss.resnik_similarity(&term1, &term2, &predicates))
     }
-
 }
 
 #[pymodule]
@@ -100,7 +129,6 @@ fn semsimian(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<Semsimian>()?;
     Ok(())
 }
-
 
 //TODO: Test the lib module.
 #[cfg(test)]

--- a/src/similarity.rs
+++ b/src/similarity.rs
@@ -299,8 +299,8 @@ mod tests {
         // the previous tests
         let result3 = calculate_semantic_jaccard_similarity(
             &closure_map2,
-            String::from("BFO:0000002"),
-            String::from("BFO:0000003"),
+            "BFO:0000002",
+            "BFO:0000003",
             &Some(sco_po_predicate.clone()),
         );
         println!("{result3}");

--- a/src/similarity.rs
+++ b/src/similarity.rs
@@ -87,7 +87,7 @@ pub fn calculate_max_information_content(
     ic_map: &HashMap<PredicateSetKey, HashMap<TermID, f64>>,
     entity1: &TermID,
     entity2: &TermID,
-    predicates: &Option<HashSet<Predicate>>
+    predicates: &Option<HashSet<Predicate>>,
 ) -> f64 {
     // CODE TO CALCULATE MAX IC
     let filtered_common_ancestors: Vec<String> =
@@ -98,16 +98,18 @@ pub fn calculate_max_information_content(
     // for each member of filtered_common_ancestors, find the entry for it in ic_map
     let mut max_ic: f64 = 0.0;
     for ancestor in filtered_common_ancestors.iter() {
-        if let Some(ic) = ic_map.get(&predicate_set_key).expect("Finding ancestor in ic map").get(ancestor) {
+        if let Some(ic) = ic_map
+            .get(&predicate_set_key)
+            .expect("Finding ancestor in ic map")
+            .get(ancestor)
+        {
             if *ic > max_ic {
                 max_ic = *ic;
-
             }
         }
     }
     // then return the String and f64 for the filtered_common_ancestors with the highest f64
     max_ic
-
 }
 
 /// Returns the common ancestors of two entities based on the given closure table and a set of predicates.
@@ -122,12 +124,10 @@ fn common_ancestors(
     // {"GO:5678": vec![('is_a', 'part_of')]: {['GO:3456', 'GO:7890']}}
 
     // {"GO:5678": 'is_a_+_part_of': {['GO:3456', 'GO:7890']}}
-
     entity1: &TermID,
     entity2: &TermID,
-    predicates: &Option<HashSet<Predicate>>
+    predicates: &Option<HashSet<Predicate>>,
 ) -> Vec<String> {
-
     // expand_term_using_closure() handles case of the entity being not present -> returning empty set
     let entity1_closure = expand_term_using_closure(entity1, closure_map, predicates);
     let entity2_closure = expand_term_using_closure(entity2, closure_map, predicates);
@@ -226,7 +226,8 @@ mod tests {
 
     #[test]
     fn test_semantic_jaccard_similarity() {
-        let mut closure_map: HashMap<PredicateSetKey, HashMap<TermID, HashSet<TermID>>> = HashMap::new();
+        let mut closure_map: HashMap<PredicateSetKey, HashMap<TermID, HashSet<TermID>>> =
+            HashMap::new();
 
         // closure map looks like this:
         // +subClassOf -> CARO:0000000 -> CARO:0000000, BFO:0000002, BFO:0000003
@@ -256,9 +257,18 @@ mod tests {
         //             -> BFO:0000002 -> BFO:0000002, BFO:0000003
         //             -> BFO:0000003 -> BFO:0000003, BFO:0000004 <- +partOf
         //             -> BFO:0000004 -> BFO:0000004
-        let mut closure_map2: HashMap<PredicateSetKey, HashMap<TermID, HashSet<TermID>>> = HashMap::new();
-        closure_map2.insert(String::from("+partOf+subClassOf"), closure_map.get("+subClassOf").unwrap().clone());
-        closure_map2.get_mut("+partOf+subClassOf").unwrap().get_mut(&String::from("BFO:0000003")).unwrap().insert(String::from("BFO:0000004"));
+        let mut closure_map2: HashMap<PredicateSetKey, HashMap<TermID, HashSet<TermID>>> =
+            HashMap::new();
+        closure_map2.insert(
+            String::from("+partOf+subClassOf"),
+            closure_map.get("+subClassOf").unwrap().clone(),
+        );
+        closure_map2
+            .get_mut("+partOf+subClassOf")
+            .unwrap()
+            .get_mut(&String::from("BFO:0000003"))
+            .unwrap()
+            .insert(String::from("BFO:0000004"));
 
         let mut sco_predicate: HashSet<Predicate> = HashSet::new();
         sco_predicate.insert(String::from("subClassOf"));
@@ -388,20 +398,28 @@ mod tests {
 
     #[test]
     fn test_calculate_max_information_content() {
-
         let ic_map: HashMap<PredicateSetKey, HashMap<TermID, f64>> = [(
-            String::from("+subClassOf"), [
+            String::from("+subClassOf"),
+            [
                 (String::from("CARO:0000000"), 2.585),
                 (String::from("BFO:0000002"), 1.585),
                 (String::from("BFO:0000003"), 1.0),
-            ].iter().cloned().collect())].iter().cloned().collect();
+            ]
+            .iter()
+            .cloned()
+            .collect(),
+        )]
+        .iter()
+        .cloned()
+        .collect();
 
         // closure map looks like this:
         // {'subClassOf': {'CARO:0000000': {'CARO:0000000', 'BFO:0000002', 'BFO:0000003'},
         //                 'BFO:0000002':  {'BFO:0000002', 'BFO:0000003'},
         //                 'BFO:0000003':  {'BFO:0000003'}}}
 
-        let mut closure_map: HashMap<PredicateSetKey, HashMap<TermID, HashSet<TermID>>> = HashMap::new();
+        let mut closure_map: HashMap<PredicateSetKey, HashMap<TermID, HashSet<TermID>>> =
+            HashMap::new();
 
         let mut map: HashMap<PredicateSetKey, HashSet<TermID>> = HashMap::new();
         let mut set: HashSet<TermID> = HashSet::new();

--- a/src/similarity.rs
+++ b/src/similarity.rs
@@ -275,8 +275,8 @@ mod tests {
 
         let result = calculate_semantic_jaccard_similarity(
             &closure_map,
-            String::from("CARO:0000000"),
-            String::from("BFO:0000002"),
+            "CARO:0000000",
+            "BFO:0000002",
             &Some(sco_predicate.clone()),
         );
         println!("{result}");
@@ -284,8 +284,8 @@ mod tests {
 
         let result2 = calculate_semantic_jaccard_similarity(
             &closure_map,
-            String::from("BFO:0000002"),
-            String::from("BFO:0000003"),
+            "BFO:0000002",
+            "BFO:0000003",
             &Some(sco_predicate.clone()),
         );
         println!("{result2}");

--- a/src/similarity.rs
+++ b/src/similarity.rs
@@ -8,13 +8,13 @@ type PredicateSetKey = String;
 
 pub fn calculate_semantic_jaccard_similarity(
     closure_table: &HashMap<String, HashMap<String, HashSet<String>>>,
-    entity1: String,
-    entity2: String,
+    entity1: &str,
+    entity2: &str,
     predicates: &Option<HashSet<String>>,
 ) -> f64 {
     /* Returns semantic Jaccard similarity between the two sets. */
-    let entity1_closure = expand_term_using_closure(&entity1, closure_table, &predicates);
-    let entity2_closure = expand_term_using_closure(&entity2, closure_table, &predicates);
+    let entity1_closure = expand_term_using_closure(entity1, closure_table, &predicates);
+    let entity2_closure = expand_term_using_closure(entity2, closure_table, &predicates);
     let jaccard = calculate_jaccard_similarity_str(&entity1_closure, &entity2_closure);
     jaccard
 }
@@ -85,13 +85,13 @@ pub fn pairwise_entity_resnik_score(
 pub fn calculate_max_information_content(
     closure_map: &HashMap<PredicateSetKey, HashMap<TermID, HashSet<TermID>>>,
     ic_map: &HashMap<PredicateSetKey, HashMap<TermID, f64>>,
-    entity1: &TermID,
-    entity2: &TermID,
+    entity1: &str,
+    entity2: &str,
     predicates: &Option<HashSet<Predicate>>,
 ) -> f64 {
     // CODE TO CALCULATE MAX IC
     let filtered_common_ancestors: Vec<String> =
-        common_ancestors(&closure_map, &entity1, &entity2, &predicates);
+        common_ancestors(closure_map, &entity1, &entity2, &predicates);
 
     let predicate_set_key = predicate_set_to_key(predicates);
 
@@ -124,8 +124,8 @@ fn common_ancestors(
     // {"GO:5678": vec![('is_a', 'part_of')]: {['GO:3456', 'GO:7890']}}
 
     // {"GO:5678": 'is_a_+_part_of': {['GO:3456', 'GO:7890']}}
-    entity1: &TermID,
-    entity2: &TermID,
+    entity1: &str,
+    entity2: &str,
     predicates: &Option<HashSet<Predicate>>,
 ) -> Vec<String> {
     // expand_term_using_closure() handles case of the entity being not present -> returning empty set
@@ -184,7 +184,7 @@ fn _calculate_information_content_scores(
     predicates: &Option<HashSet<String>>,
 ) -> HashMap<String, f64> {
     let (term_frequencies, corpus_size) =
-        calculate_term_frequencies_and_corpus_size(closure_table, predicates);
+        _calculate_term_frequencies_and_corpus_size(closure_table, predicates);
 
     let mut ic_scores = HashMap::new();
     for ancestor in filtered_common_ancestors {
@@ -197,7 +197,7 @@ fn _calculate_information_content_scores(
     ic_scores
 }
 
-fn calculate_term_frequencies_and_corpus_size(
+fn _calculate_term_frequencies_and_corpus_size(
     closure_table: &HashMap<String, HashMap<String, HashSet<String>>>,
     predicates: &Option<HashSet<String>>,
 ) -> (HashMap<String, usize>, usize) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
-use std::collections::{HashMap, HashSet};
 use indicatif::{ProgressBar, ProgressStyle};
+use std::collections::{HashMap, HashSet};
 
 type Predicate = String;
 type TermID = String;
@@ -11,7 +11,12 @@ pub fn predicate_set_to_key(predicates: &Option<HashSet<Predicate>>) -> Predicat
     if predicates.is_none() {
         result.push_str("_all");
     } else {
-        let mut vec_of_predicates: Vec<String> = predicates.as_ref().unwrap().iter().map(|x| x.to_string()).collect();
+        let mut vec_of_predicates: Vec<String> = predicates
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|x| x.to_string())
+            .collect();
         vec_of_predicates.sort();
 
         for predicate in vec_of_predicates {
@@ -73,7 +78,10 @@ pub fn _stringify_sets_using_map(
 pub fn convert_list_of_tuples_to_hashmap(
     list_of_tuples: &Vec<(TermID, PredicateSetKey, TermID)>,
     predicates: &Option<HashSet<String>>,
-) -> (HashMap<String, HashMap<String, HashSet<String>>>, HashMap<String, HashMap<String, f64>>) {
+) -> (
+    HashMap<String, HashMap<String, HashSet<String>>>,
+    HashMap<String, HashMap<String, f64>>,
+) {
     let mut closure_map: HashMap<String, HashMap<String, HashSet<String>>> = HashMap::new();
     let mut freq_map: HashMap<String, usize> = HashMap::new();
     let mut ic_map: HashMap<String, HashMap<String, f64>> = HashMap::new();
@@ -84,8 +92,10 @@ pub fn convert_list_of_tuples_to_hashmap(
     let progress_bar = ProgressBar::new(list_of_tuples.len() as u64);
     progress_bar.set_style(
         ProgressStyle::default_bar()
-            .template("[{elapsed_precise}] Building closure and IC map: {bar:40.cyan/blue} {percent}%")
-            .unwrap()
+            .template(
+                "[{elapsed_precise}] Building closure and IC map: {bar:40.cyan/blue} {percent}%",
+            )
+            .unwrap(),
     );
 
     for (s, p, o) in list_of_tuples.iter() {
@@ -121,8 +131,6 @@ pub fn convert_list_of_tuples_to_hashmap(
     (closure_map, ic_map)
 }
 
-
-
 pub fn expand_term_using_closure(
     term: &TermID,
     closure_table: &HashMap<PredicateSetKey, HashMap<TermID, HashSet<TermID>>>,
@@ -140,7 +148,6 @@ pub fn expand_term_using_closure(
     }
     ancestors
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -245,39 +252,69 @@ mod tests {
         ];
 
         // test closure map for is_a predicates
-        let expected_closure_map_is_a: HashMap<PredicateSetKey, HashMap<TermID, HashSet<TermID>>> = HashMap::from([
-            (
-                String::from("+is_a"), HashMap::from([
-                    (String::from("ABCD:123"), [String::from("BCDE:234")].iter().cloned().collect::<HashSet<_>>()),
-                    (String::from("XYZ:123"), [String::from("WXY:234")].iter().cloned().collect::<HashSet<_>>()),
-                ]),
-            ),
-        ]);
-
-        let predicates_is_a: Option<HashSet<Predicate>> = Some(["is_a"].iter().map(|&s| s.to_string()).collect());
-        let (closure_map_is_a, _) = convert_list_of_tuples_to_hashmap(&list_of_tuples, &predicates_is_a);
-        assert_eq!(expected_closure_map_is_a, closure_map_is_a);
-
-        // test closure_map for is_a + part_of predicates
-        let expected_closure_map_is_a_plus_part_of: HashMap<PredicateSetKey, HashMap<TermID, HashSet<TermID>>> = HashMap::from([
-            (
-                String::from("+is_a+part_of"),
+        let expected_closure_map_is_a: HashMap<PredicateSetKey, HashMap<TermID, HashSet<TermID>>> =
+            HashMap::from([(
+                String::from("+is_a"),
                 HashMap::from([
                     (
                         String::from("ABCD:123"),
-                        HashSet::from([String::from("BCDE:234"), String::from("ABCDE:1234")].iter().cloned().collect::<HashSet<TermID>>()),
+                        [String::from("BCDE:234")]
+                            .iter()
+                            .cloned()
+                            .collect::<HashSet<_>>(),
                     ),
                     (
                         String::from("XYZ:123"),
-                        HashSet::from([String::from("WXY:234"), String::from("WXYZ:1234")].iter().cloned().collect::<HashSet<TermID>>()),
+                        [String::from("WXY:234")]
+                            .iter()
+                            .cloned()
+                            .collect::<HashSet<_>>(),
                     ),
                 ]),
-            ),
-        ]);
+            )]);
 
-        let predicates_is_a_plus_part_of: Option<HashSet<Predicate>> = Some(["is_a", "part_of"].iter().map(|&s| s.to_string()).collect());
-        let (closure_map_is_a_plus_part_of, ic_map) = convert_list_of_tuples_to_hashmap(&list_of_tuples, &predicates_is_a_plus_part_of);
-        assert_eq!(expected_closure_map_is_a_plus_part_of, closure_map_is_a_plus_part_of);
+        let predicates_is_a: Option<HashSet<Predicate>> =
+            Some(["is_a"].iter().map(|&s| s.to_string()).collect());
+        let (closure_map_is_a, _) =
+            convert_list_of_tuples_to_hashmap(&list_of_tuples, &predicates_is_a);
+        assert_eq!(expected_closure_map_is_a, closure_map_is_a);
+
+        // test closure_map for is_a + part_of predicates
+        let expected_closure_map_is_a_plus_part_of: HashMap<
+            PredicateSetKey,
+            HashMap<TermID, HashSet<TermID>>,
+        > = HashMap::from([(
+            String::from("+is_a+part_of"),
+            HashMap::from([
+                (
+                    String::from("ABCD:123"),
+                    HashSet::from(
+                        [String::from("BCDE:234"), String::from("ABCDE:1234")]
+                            .iter()
+                            .cloned()
+                            .collect::<HashSet<TermID>>(),
+                    ),
+                ),
+                (
+                    String::from("XYZ:123"),
+                    HashSet::from(
+                        [String::from("WXY:234"), String::from("WXYZ:1234")]
+                            .iter()
+                            .cloned()
+                            .collect::<HashSet<TermID>>(),
+                    ),
+                ),
+            ]),
+        )]);
+
+        let predicates_is_a_plus_part_of: Option<HashSet<Predicate>> =
+            Some(["is_a", "part_of"].iter().map(|&s| s.to_string()).collect());
+        let (closure_map_is_a_plus_part_of, ic_map) =
+            convert_list_of_tuples_to_hashmap(&list_of_tuples, &predicates_is_a_plus_part_of);
+        assert_eq!(
+            expected_closure_map_is_a_plus_part_of,
+            closure_map_is_a_plus_part_of
+        );
 
         let expected_ic_map_is_a_plus_part_of: HashMap<PredicateSetKey, HashMap<TermID, f64>> = {
             let mut expected: HashMap<TermID, f64> = HashMap::new();
@@ -285,38 +322,54 @@ mod tests {
 
             expected.insert(String::from("ABCD:123"), -(2.0 / total_count as f64).log2());
             expected.insert(String::from("BCDE:234"), -(1.0 / total_count as f64).log2());
-            expected.insert(String::from("ABCDE:1234"), -(1.0 / total_count as f64).log2());
+            expected.insert(
+                String::from("ABCDE:1234"),
+                -(1.0 / total_count as f64).log2(),
+            );
             expected.insert(String::from("XYZ:123"), -(2.0 / total_count as f64).log2());
             expected.insert(String::from("WXY:234"), -(1.0 / total_count as f64).log2());
-            expected.insert(String::from("WXYZ:1234"), -(1.0 / total_count as f64).log2());
+            expected.insert(
+                String::from("WXYZ:1234"),
+                -(1.0 / total_count as f64).log2(),
+            );
 
-            let mut expected_ic_map_is_a_plus_part_of: HashMap<PredicateSetKey, HashMap<TermID, f64>> = HashMap::new();
+            let mut expected_ic_map_is_a_plus_part_of: HashMap<
+                PredicateSetKey,
+                HashMap<TermID, f64>,
+            > = HashMap::new();
             expected_ic_map_is_a_plus_part_of.insert(String::from("+is_a+part_of"), expected);
             expected_ic_map_is_a_plus_part_of
         };
 
         assert_eq!(ic_map, expected_ic_map_is_a_plus_part_of);
-        
     }
 
     #[test]
-    fn test_predicate_set_to_string(){
-        let predicates_is_a: Option<HashSet<Predicate>> = Some(["is_a"].iter().map(|&s| s.to_string()).collect());
-        let predicates_is_a_part_of: Option<HashSet<Predicate>> = Some(["is_a", "part_of"].iter().map(|&s| s.to_string()).collect());
-        let predicates_part_of_is_a: Option<HashSet<Predicate>> = Some(["part_of", "is_a"].iter().map(|&s| s.to_string()).collect());
+    fn test_predicate_set_to_string() {
+        let predicates_is_a: Option<HashSet<Predicate>> =
+            Some(["is_a"].iter().map(|&s| s.to_string()).collect());
+        let predicates_is_a_part_of: Option<HashSet<Predicate>> =
+            Some(["is_a", "part_of"].iter().map(|&s| s.to_string()).collect());
+        let predicates_part_of_is_a: Option<HashSet<Predicate>> =
+            Some(["part_of", "is_a"].iter().map(|&s| s.to_string()).collect());
         let predicates_empty: Option<HashSet<Predicate>> = None;
 
         assert_eq!(predicate_set_to_key(&predicates_is_a), "+is_a");
-        assert_eq!(predicate_set_to_key(&predicates_is_a_part_of), "+is_a+part_of");
-        assert_eq!(predicate_set_to_key(&predicates_part_of_is_a), "+is_a+part_of");
+        assert_eq!(
+            predicate_set_to_key(&predicates_is_a_part_of),
+            "+is_a+part_of"
+        );
+        assert_eq!(
+            predicate_set_to_key(&predicates_part_of_is_a),
+            "+is_a+part_of"
+        );
         assert_eq!(predicate_set_to_key(&predicates_empty), "_all");
     }
 
-
-
     #[test]
     fn test_expand_term_using_closure() {
-        let mut closure_table: HashMap<PredicateSetKey, HashMap<TermID, HashSet<TermID>>> = HashMap::new();
+        let mut closure_table: HashMap<PredicateSetKey, HashMap<TermID, HashSet<TermID>>> =
+            HashMap::new();
         let mut map: HashMap<PredicateSetKey, HashSet<TermID>> = HashMap::new();
         let mut set: HashSet<TermID> = HashSet::new();
         set.insert(String::from("CARO:0000000"));
@@ -337,7 +390,8 @@ mod tests {
         closure_table.insert(String::from("+subClassOf"), map);
 
         let term = String::from("CARO:0000000");
-        let predicates: Option<HashSet<Predicate>> = Some(HashSet::from(["subClassOf".to_string()]));
+        let predicates: Option<HashSet<Predicate>> =
+            Some(HashSet::from(["subClassOf".to_string()]));
         let result = expand_term_using_closure(&term, &closure_table, &predicates);
 
         let expected_result = HashSet::from([

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -132,7 +132,7 @@ pub fn convert_list_of_tuples_to_hashmap(
 }
 
 pub fn expand_term_using_closure(
-    term: &TermID,
+    term: &str,
     closure_table: &HashMap<PredicateSetKey, HashMap<TermID, HashSet<TermID>>>,
     predicates: &Option<HashSet<Predicate>>,
 ) -> HashSet<TermID> {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -37,8 +37,8 @@ fn integration_test_semantic_jaccard_similarity() {
     let (closure_table, _) = convert_list_of_tuples_to_hashmap(&list_of_tuples, &predicate_set);
     let sem_jaccard = calculate_semantic_jaccard_similarity(
         &closure_table,
-        "apple".to_string(),
-        "cherry".to_string(),
+        "apple",
+        "cherry",
         &Some(HashSet::from(["is_a".to_string()])),
     );
 


### PR DESCRIPTION
My misconception was that all `String`s could be converted to `&str`s. The key is to understand that **only functions** that took `String` objects as parameters could be changed to accept `&str`. The rest for e.g. `HashSet<String>` , `HashMap<String, HashMap<String, HashSet<String>>>` should stay as is. `&str` is a 'slice' of the `String` object and hence cannot replace it.



[More reading about the concept if needed.](https://stackoverflow.com/a/24159933/947778)


This PR also formats the code hence the vast differences.