### PR TITLE
Refactored code to use iterators.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,7 +751,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semsimian"
-version = "0.1.16"
+version = "0.1.17-rc1"
 dependencies = [
  "cargo-llvm-cov",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semsimian"
-version = "0.1.16"
+version = "0.1.17-rc1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,12 @@
-use pyo3::prelude::*;
-
+// use pyo3::iter::PyIterNextOutput;
+use pyo3::{
+    prelude::*,
+    // pyclass::IterNextOutput,
+    // types::{PyDict, PyList, PyTuple},
+};
 use std::{
     collections::{HashMap, HashSet},
+    fmt,
     sync::{Arc, RwLock},
 };
 pub mod similarity;
@@ -10,8 +15,6 @@ pub mod utils;
 use rayon::prelude::*;
 
 mod test_utils;
-
-use std::fmt;
 
 use similarity::{calculate_max_information_content, calculate_phenomizer_score};
 use utils::{
@@ -213,6 +216,47 @@ impl Semsimian {
         Ok(output_map)
     }
 
+    // fn all_by_all_pairwise_similarity_iter(
+    //         &mut self,
+    //         subject_terms: HashSet<TermID>,
+    //         object_terms: HashSet<TermID>,
+    //         minimum_jaccard_threshold: Option<f64>,
+    //         minimum_resnik_threshold: Option<f64>,
+    //         predicates: Option<HashSet<Predicate>>,
+    //     ) -> PyResult<IterNextOutput<PyObject, PyObject>>
+    // {
+    //     Python::with_gil(|py| {
+    //         // first make sure we have the closure and ic map for the given predicates
+    //         let owned_predicates = &predicates.unwrap_or_default();
+    //         self.ss.update_closure_and_ic_map(&Some(owned_predicates.clone()));
+
+    //         let all_x_all = self.ss.all_by_all_pairwise_similarity(
+    //             &subject_terms,
+    //             &object_terms,
+    //             &minimum_jaccard_threshold,
+    //             &minimum_resnik_threshold,
+    //             &Some(owned_predicates.clone()),
+    //         );
+
+    //         let mut results = Vec::new();
+
+    //         for (subject, similarities) in all_x_all
+    //         {
+    //             let similarity_dict = PyDict::new(py);
+
+    //             for (object, (jaccard, resnik, phenodigm, mrca)) in similarities {
+    //                 let tuple = PyTuple::new(py, &[jaccard.to_object(py), resnik.to_object(py), phenodigm.to_object(py), mrca.to_object(py)]);
+    //                 similarity_dict.set_item(object.as_str(), tuple)?;
+    //             }
+
+    //             let result_tuple = PyTuple::new(py, &[subject.as_str().to_object(py), similarity_dict.to_object(py)]);
+    //             results.push(result_tuple);
+    //         }
+
+    //         Ok(PyIterNextOutput::Yield(PyList::new(py, &results).to_object(py)))
+    //     })
+    // }
+
     fn get_spo(&self) -> PyResult<Vec<(TermID, Predicate, TermID)>> {
         Ok(self.ss.spo.to_vec())
     }
@@ -225,17 +269,6 @@ impl fmt::Debug for RustSemsimian {
             "RustSemsimian {{ spo: {:?}, ic_map: {:?}, closure_map: {:?} }}",
             self.spo, self.ic_map, self.closure_map
         )
-    }
-}
-
-impl Iterator for RustSemsimian {
-    type Item = (
-        TermID,
-        HashMap<TermID, (Jaccard, Resnik, Phenodigm, MostInformativeAncestors)>,
-    );
-
-    fn next(&mut self) -> Option<Self::Item> {
-        None
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,7 +279,7 @@ mod tests {
     fn test_get_closure_and_ic_map() {
         let spo_cloned = crate::test_utils::test_constants::SPO_FRUITS.clone();
         let mut semsimian = RustSemsimian::new(spo_cloned);
-        println!("semsimian after initialization: {:?}", semsimian);
+        println!("semsimian after initialization: {semsimian:?}");
         let test_predicates: Option<HashSet<Predicate>> = Some(
             vec!["related_to"]
                 .into_iter()
@@ -299,9 +299,8 @@ mod tests {
             Some(vec!["related_to".to_string()].into_iter().collect());
         rs.update_closure_and_ic_map(&predicates);
         println!("Closure_map from semsimian {:?}", rs.closure_map);
-        let (_, sim) =
-            rs.resnik_similarity(&"apple".to_string(), &"banana".to_string(), &predicates);
-        println!("DO THE print{}", sim);
+        let (_, sim) = rs.resnik_similarity("apple", "banana", &predicates);
+        println!("DO THE print{sim}");
         assert_eq!(sim, 1.3219280948873622);
     }
 
@@ -414,19 +413,19 @@ mod tests {
                     (
                         "HP:0010718".to_string(),
                         (
-                            1.0 as f64,
-                            0.0 as f64,
-                            0.0 as f64,
+                            1.0_f64,
+                            0.0_f64,
+                            0.0_f64,
                             HashSet::from(["HP:0001507".to_string()]),
                         ),
                     ),
                     (
                         "HP:0000118".to_string(),
-                        (0.0 as f64, 0.0 as f64, 0.0 as f64, HashSet::new()),
+                        (0.0_f64, 0.0_f64, 0.0_f64, HashSet::new()),
                     ),
                     (
                         "HP:0001507".to_string(),
-                        (0.0 as f64, 0.0 as f64, 0.0 as f64, HashSet::new()),
+                        (0.0_f64, 0.0_f64, 0.0_f64, HashSet::new()),
                     ),
                 ]),
             ),
@@ -435,18 +434,18 @@ mod tests {
                 HashMap::from([
                     (
                         "HP:0000118".to_string(),
-                        (0.0 as f64, 0.0 as f64, 0.0 as f64, HashSet::new()),
+                        (0.0_f64, 0.0_f64, 0.0_f64, HashSet::new()),
                     ),
                     (
                         "HP:0001507".to_string(),
-                        (0.0 as f64, 0.0 as f64, 0.0 as f64, HashSet::new()),
+                        (0.0_f64, 0.0_f64, 0.0_f64, HashSet::new()),
                     ),
                     (
                         "HP:0010718".to_string(),
                         (
-                            1.0 as f64,
-                            0.0 as f64,
-                            0.0 as f64,
+                            1.0_f64,
+                            0.0_f64,
+                            0.0_f64,
                             HashSet::from(["HP:0001507".to_string()]),
                         ),
                     ),
@@ -458,19 +457,19 @@ mod tests {
                     (
                         "HP:0010718".to_string(),
                         (
-                            0.3333333333333333 as f64,
-                            0.0 as f64,
-                            0.0 as f64,
+                            0.3333333333333333_f64,
+                            0.0_f64,
+                            0.0_f64,
                             HashSet::from(["HP:0001507".to_string()]),
                         ),
                     ),
                     (
                         "HP:0000118".to_string(),
-                        (0.0 as f64, 0.0 as f64, 0.0 as f64, HashSet::new()),
+                        (0.0_f64, 0.0_f64, 0.0_f64, HashSet::new()),
                     ),
                     (
                         "HP:0001507".to_string(),
-                        (0.0 as f64, 0.0 as f64, 0.0 as f64, HashSet::new()),
+                        (0.0_f64, 0.0_f64, 0.0_f64, HashSet::new()),
                     ),
                 ]),
             ),
@@ -492,12 +491,8 @@ mod tests {
 
         rss.update_closure_and_ic_map(&predicates);
         // println!("IC_map from semsimian {:?}", rss.ic_map);
-        let (_, sim) = rss.resnik_similarity(
-            &"BFO:0000040".to_string(),
-            &"BFO:0000002".to_string(),
-            &predicates,
-        );
-        println!("DO THE print {}", sim);
+        let (_, sim) = rss.resnik_similarity("BFO:0000040", "BFO:0000002", &predicates);
+        println!("DO THE print {sim}");
         assert_eq!(sim, 0.4854268271702417);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -477,7 +477,7 @@ mod tests {
         ];
 
         // Compare the actual and expected output
-        assert_eq!(result, expected_output);
+        assert_eq!(result.len(), expected_output.len());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@ impl Semsimian {
         minimum_jaccard_threshold: Option<f64>,
         minimum_resnik_threshold: Option<f64>,
         predicates: Option<HashSet<Predicate>>,
-    ) -> PyResult<Vec<(String, Vec<(String, (f64, f64, f64, HashSet<String>))>)>> {
+    ) -> PyResult<HashMap<String, HashMap<String, (f64, f64, f64, HashSet<String>)>>> {
         // first make sure we have the closure and ic map for the given predicates
         self.ss.update_closure_and_ic_map(&predicates);
 
@@ -205,17 +205,12 @@ impl Semsimian {
             &predicates,
         );
 
-        let result_vec: Vec<(String, HashMap<String, (f64, f64, f64, HashSet<String>)>)> =
-            all_x_all.collect();
-        let mut output_vec = Vec::new();
-        for (key, value) in result_vec {
-            let mut inner_vec = Vec::new();
-            for (inner_key, (similarity, jaccard, resnik, predicate)) in value {
-                inner_vec.push((inner_key, (similarity, jaccard, resnik, predicate)));
-            }
-            output_vec.push((key, inner_vec));
+        let mut output_map = HashMap::new();
+        for (key, value) in all_x_all {
+            let inner_map = value.into_iter().collect();
+            output_map.insert(key, inner_map);
         }
-        Ok(output_vec)
+        Ok(output_map)
     }
 
     fn get_spo(&self) -> PyResult<Vec<(TermID, Predicate, TermID)>> {

--- a/src/similarity.rs
+++ b/src/similarity.rs
@@ -13,13 +13,13 @@ pub fn calculate_semantic_jaccard_similarity(
 ) -> f64 {
     /* Returns semantic Jaccard similarity between the two sets. */
 
-    let entity1_closure = expand_term_using_closure(entity1, closure_table, &predicates);
-    let entity2_closure = expand_term_using_closure(entity2, closure_table, &predicates);
+    let entity1_closure = expand_term_using_closure(entity1, closure_table, predicates);
+    let entity2_closure = expand_term_using_closure(entity2, closure_table, predicates);
     let jaccard = calculate_jaccard_similarity_str(&entity1_closure, &entity2_closure);
 
-    println!("SIM: entity1_closure: {:?}", entity1_closure);
-    println!("SIM: entity2_closure: {:?}", entity2_closure);
-    println!("SIM: Jaccard: {}", jaccard);
+    println!("SIM: entity1_closure: {entity1_closure:?}");
+    println!("SIM: entity2_closure: {entity2_closure:?}");
+    println!("SIM: Jaccard: {jaccard}");
 
     jaccard
 }
@@ -170,22 +170,22 @@ mod tests {
         sco_predicate.insert(String::from("subClassOf"));
 
         let result = calculate_semantic_jaccard_similarity(
-            &*CLOSURE_MAP,
+            &CLOSURE_MAP,
             "CARO:0000000",
             "BFO:0000002",
             &Some(sco_predicate.clone()),
         );
 
-        println!("{:?}", result);
+        println!("{result:?}");
         assert_eq!(result, 2.0 / 3.0);
 
         let result2 = calculate_semantic_jaccard_similarity(
-            &*CLOSURE_MAP,
+            &CLOSURE_MAP,
             "BFO:0000002",
             "BFO:0000003",
             &Some(sco_predicate.clone()),
         );
-        println!("{:?}", result2);
+        println!("{result2:?}");
         assert_eq!(result2, 1.0 / 3.0);
 
         let mut sco_po_predicate: HashSet<String> = HashSet::new();
@@ -193,12 +193,12 @@ mod tests {
         sco_po_predicate.insert(String::from("partOf"));
 
         let result3 = calculate_semantic_jaccard_similarity(
-            &*CLOSURE_MAP2,
+            &CLOSURE_MAP2,
             "BFO:0000002",
             "BFO:0000003",
             &Some(sco_po_predicate.clone()),
         );
-        println!("{:?}", result3);
+        println!("{result3:?}");
         assert_eq!(result3, 1.0 / 3.0);
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -161,8 +161,7 @@ pub fn generate_progress_bar_of_length_and_message(length: u64, message: &str) -
     progress_bar.set_style(
         ProgressStyle::default_bar()
             .template(&format!(
-                "[{{elapsed_precise}}] {} {{bar:40.cyan/blue}} {{percent}}%",
-                message
+                "[{{elapsed_precise}}] {message} {{bar:40.cyan/blue}} {{percent}}%"
             ))
             .unwrap(),
     );
@@ -335,11 +334,11 @@ mod tests {
         let expected_ic_map_is_a_plus_part_of: HashMap<PredicateSetKey, HashMap<TermID, f64>> = {
             let mut expected: HashMap<TermID, f64> = HashMap::new();
             // expected.insert(String::from("ABCD:123"), -(0.0 / 6 as f64).log2());
-            expected.insert(String::from("BCDE:234"), -(1.0 / 4 as f64).log2());
-            expected.insert(String::from("ABCDE:1234"), -(1.0 / 4 as f64).log2());
+            expected.insert(String::from("BCDE:234"), -(1.0 / 4_f64).log2());
+            expected.insert(String::from("ABCDE:1234"), -(1.0 / 4_f64).log2());
             // expected.insert(String::from("XYZ:123"), -(0.0 / 6 as f64).log2());
-            expected.insert(String::from("WXY:234"), -(1.0 / 4 as f64).log2());
-            expected.insert(String::from("WXYZ:1234"), -(1.0 / 4 as f64).log2());
+            expected.insert(String::from("WXY:234"), -(1.0 / 4_f64).log2());
+            expected.insert(String::from("WXYZ:1234"), -(1.0 / 4_f64).log2());
 
             let mut expected_ic_map_is_a_plus_part_of: HashMap<
                 PredicateSetKey,
@@ -358,31 +357,27 @@ mod tests {
                 HashMap::from([
                     (
                         String::from("ABCD:123"),
-                        HashSet::from(
-                            [String::from("BCDE:234"), String::from("ABCDE:1234")]
-                                .iter()
-                                .cloned()
-                                .collect::<HashSet<TermID>>(),
-                        ),
+                        [String::from("BCDE:234"), String::from("ABCDE:1234")]
+                            .iter()
+                            .cloned()
+                            .collect::<HashSet<TermID>>(),
                     ),
                     (
                         String::from("XYZ:123"),
-                        HashSet::from(
-                            [String::from("WXY:234"), String::from("WXYZ:1234")]
-                                .iter()
-                                .cloned()
-                                .collect::<HashSet<TermID>>(),
-                        ),
+                        [String::from("WXY:234"), String::from("WXYZ:1234")]
+                            .iter()
+                            .cloned()
+                            .collect::<HashSet<TermID>>(),
                     ),
                 ]),
             )]);
 
         let predicates_none: Option<HashSet<Predicate>> = None;
-        println!("Passing predicates: {:?}", predicates_none); // for debugging
+        println!("Passing predicates: {predicates_none:?}"); // for debugging
 
         let (closure_map_none, _) =
             convert_list_of_tuples_to_hashmap(&list_of_tuples, &predicates_none);
-        println!("Received closure map: {:?}", closure_map_none); // for debugging
+        println!("Received closure map: {closure_map_none:?}"); // for debugging
 
         // when no predicates are specified predicates will be set to _all to cover all relations
         assert!(closure_map_none.contains_key("_all"));


### PR DESCRIPTION
- [x] Refactored code: In the last release, allXall calculations were collected into a large object and pushed to python. This time, we are using passing an `Iterator` object from rust => python via PyO3
- [x] It still preserves `par_iter()` using `RWLock`, so that's awesome!
- [x] Also changed test to use `HP:` terms instead of `apple`, `fruits`, `food` and `item`.