### PR TITLE
Avoid repetitive closure & ic_map creation.

### DIFF
--- a/python/tests/test_python.py
+++ b/python/tests/test_python.py
@@ -95,13 +95,14 @@ class testSemsimianWithPython(unittest.TestCase):
             resource_path=self.db,
         )
         _ = semsimian.termset_pairwise_similarity(subject_terms, object_terms)
-        interval_1 = time.time() - load_start
+        interval_1 = round((time.time() - load_start), 10)
         logging.debug(f"Warmup time: {interval_1} sec")
         second_compare_time = time.time()
         _ = semsimian.termset_pairwise_similarity(subject_terms, object_terms)
-        interval_2 = time.time() - second_compare_time
+        interval_2 = round((time.time() - second_compare_time), 10)
         logging.debug(f"Second compare time: {interval_2} sec")
         self.assertGreater(interval_1, interval_2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_python.py
+++ b/python/tests/test_python.py
@@ -1,4 +1,5 @@
-import os
+import logging
+import time
 import unittest
 from semsimian import Semsimian
 from pathlib import Path
@@ -82,6 +83,25 @@ class testSemsimianWithPython(unittest.TestCase):
         self.assertEqual(tsps["average_score"], 5.4154243283740175)
         self.assertEqual(tsps["best_score"], 5.8496657269155685)
 
+    def test_building_closure_ic_map_once(self):
+        load_start = time.time()
+        subject_terms = {"GO:0005634", "GO:0016020"}
+        object_terms = {"GO:0031965", "GO:0005773"}
+        predicates = ["rdfs:subClassOf", "BFO:0000050"]
+        semsimian = Semsimian(
+            spo=None,
+            predicates=predicates,
+            pairwise_similarity_attributes=None,
+            resource_path=self.db,
+        )
+        _ = semsimian.termset_pairwise_similarity(subject_terms, object_terms)
+        interval_1 = time.time() - load_start
+        logging.debug(f"Warmup time: {interval_1} sec")
+        second_compare_time = time.time()
+        _ = semsimian.termset_pairwise_similarity(subject_terms, object_terms)
+        interval_2 = time.time() - second_compare_time
+        logging.debug(f"Second compare time: {interval_2} sec")
+        self.assertGreater(interval_1, interval_2)
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,16 +117,21 @@ impl RustSemsimian {
 
     pub fn update_closure_and_ic_map(&mut self) {
         let predicate_set_key = predicate_set_to_key(&self.predicates);
-        let (this_closure_map, this_ic_map) =
-            convert_list_of_tuples_to_hashmap(&self.spo, &self.predicates);
-        self.closure_map.insert(
-            predicate_set_key.clone(),
-            this_closure_map.get(&predicate_set_key).unwrap().clone(),
-        );
-        self.ic_map.insert(
-            predicate_set_key.clone(),
-            this_ic_map.get(&predicate_set_key).unwrap().clone(),
-        );
+
+        if !self.closure_map.contains_key(&predicate_set_key)
+            || !self.ic_map.contains_key(&predicate_set_key)
+        {
+            let (this_closure_map, this_ic_map) =
+                convert_list_of_tuples_to_hashmap(&self.spo, &self.predicates);
+            self.closure_map.insert(
+                predicate_set_key.clone(),
+                this_closure_map.get(&predicate_set_key).unwrap().clone(),
+            );
+            self.ic_map.insert(
+                predicate_set_key.clone(),
+                this_ic_map.get(&predicate_set_key).unwrap().clone(),
+            );
+        }
     }
 
     pub fn load_embeddings(&mut self, embeddings_file: &str) {
@@ -186,7 +191,7 @@ impl RustSemsimian {
         let self_shared = Arc::new(RwLock::new(self.clone()));
         let pb = generate_progress_bar_of_length_and_message(
             (subject_terms.len() * object_terms.len()) as u64,
-            "Building all X all pairwise similarity:",
+            "Building (all subjects X all objects) pairwise similarity:",
         );
 
         let similarity_map: SimilarityMap = subject_terms
@@ -242,7 +247,7 @@ impl RustSemsimian {
         let self_shared = Arc::new(RwLock::new(self.clone()));
         let pb = generate_progress_bar_of_length_and_message(
             (subject_terms.len() * object_terms.len()) as u64,
-            "Building all X all pairwise similarity:",
+            "Building (all subjects X all objects) pairwise similarity:",
         );
         let outfile = outfile.unwrap_or("similarity_map.tsv");
         let file = File::create(outfile).unwrap();


### PR DESCRIPTION
Fixes #89

- [x] Makes sure that `closure_map` and `ic_map` are built just once
- [x] Minor optimization in `util.rs` eliminating a `for` loop and replacing it with `.iter()`.