### PR TITLE
Added test for comparing 2 runs of termset_pairwise_similarity

### DIFF
--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -57,7 +57,7 @@ jobs:
         # genhtml -o output coverage.lcov
 
         # run python tests
-        pytest python/tests --cov-report xml --cov-report term-missing
+        pytest python/tests --cov-report xml --cov-report term-missing --capture=no
 
     # - name: Upload coverage to Codecov
     #   uses: codecov/codecov-action@v3.1.1

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -49,7 +49,7 @@ jobs:
         # The second provides a plain-text report to the stdout
         # cargo llvm-cov --lcov --output-path coverage.lcov
 
-        cargo llvm-cov
+        cargo llvm-cov --features ci
 
         # Convert the coverage report to more readable html
         

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 python/semsimian/semsimian.cpython-39-darwin.so
 .vscode/launch.json
 tests/data/output/*.tsv
+flamegraph.svg

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,28 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
+ "getrandom",
  "once_cell",
  "version_check",
 ]
@@ -23,10 +39,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "anyhow"
@@ -35,10 +115,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
+name = "async-compression"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b74f44609f0f91493e3082d3734d98497e094777144380ea4db9f9905dd5b6"
+dependencies = [
+ "brotli",
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object 0.32.0",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "base64"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+
+[[package]]
+name = "binary-merge"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597bb81c80a54b6a4381b23faba8d7774b144c94cbd1d6fe3f1329bd776554ab"
 
 [[package]]
 name = "bitflags"
@@ -53,6 +180,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
+name = "blondie"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b8ee271efa6507b9b646dc0e8150f61bcb526a7f213b4e2b8ef1924393f075"
+dependencies = [
+ "object 0.30.4",
+ "pdb-addr2line",
+ "rustc-hash",
+ "symsrv",
+ "tokio",
+ "windows 0.44.0",
+]
+
+[[package]]
+name = "brotli"
+version = "3.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bstr"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,6 +223,42 @@ dependencies = [
  "memchr",
  "regex-automata",
  "serde",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+
+[[package]]
+name = "bytemuck"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
+name = "cab"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae6b4de23c7d39c0631fd3cc952d87951c86c75a13812d7247cb7a896e7b3551"
+dependencies = [
+ "byteorder",
+ "flate2",
+ "lzxd",
+ "time",
 ]
 
 [[package]]
@@ -159,6 +357,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "4.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb690e81c7840c0d7aade59f242ea3b41b9bc27bcd5997890e7702ae4b32e487"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ed2e96bc16d8d740f6f48d663eddf4b8a0983e79210fd55479b7bcd0a69860e"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc443334c81a804575546c5a8a79b4913b50e28d69232903604cada1de817ce"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.26",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
 name = "console"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +423,15 @@ dependencies = [
  "libc",
  "unicode-width",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -236,10 +499,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd72493923899c6f10c641bdbdeddc7183d6396641d99c1a0d1597f37f92e28"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.0",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+
+[[package]]
 name = "dict"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39fbb71fba1e2c935f51b056de0d812d9b625b8165b2d7f8848902080fbdffb4"
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
 
 [[package]]
 name = "duct"
@@ -260,10 +562,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
+name = "elsa"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714f766f3556b44e7e4776ad133fcc3445a489517c25c704ace411bb14790194"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -305,10 +625,104 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "flamegraph"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be72bf9a0e0e0dbf0903f3dd6423c57a37b61bf851ae18a3bd47c1a8da604c4d"
+dependencies = [
+ "anyhow",
+ "blondie",
+ "cargo_metadata",
+ "clap",
+ "clap_complete",
+ "inferno",
+ "opener",
+ "shlex",
+ "signal-hook",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fs-err"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0845fa252299212f0389d64ba26f34fa32cfe41588355f21ed507c59a0f64541"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.26",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-util"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "generator"
@@ -320,14 +734,56 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows",
+ "windows 0.48.0",
 ]
+
+[[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "gimli"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "h2"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap 1.9.3",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -345,8 +801,14 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "312f66718a2d7789ffef4f4b7b213138ed9f1eb3aa1d0d82fc99f88fb3ffd26f"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.0",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -364,13 +826,105 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.4.9",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
+name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -393,6 +947,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
 
 [[package]]
+name = "inferno"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73c0fefcb6d409a6587c07515951495d482006f89a21daa0f2f783aa4fd5e027"
+dependencies = [
+ "ahash",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "dashmap",
+ "indexmap 2.0.0",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
+name = "inplace-vec-builder"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf64c2edc8226891a71f127587a2861b132d2b942310843814d5001d99a1d307"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,6 +984,12 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "is-terminal"
@@ -426,6 +1016,15 @@ name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "js-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -491,10 +1090,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
+name = "lzxd"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784462f20dddd9dfdb45de963fa4ad4a288cb10a7889ac5d2c34fb6481c6b213"
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memmap2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -506,12 +1126,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "normpath"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec60c60a693226186f5d6edf073232bfb6464ed97eb22cf3b01c1e8198fd97f5"
 dependencies = [
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
 ]
 
 [[package]]
@@ -538,6 +1194,25 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "object"
+version = "0.30.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
+dependencies = [
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "once_cell"
@@ -593,10 +1268,53 @@ checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "smallvec",
  "windows-targets 0.48.1",
 ]
+
+[[package]]
+name = "pdb"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82040a392923abe6279c00ab4aff62d5250d1c8555dc780e4b02783a7aa74863"
+dependencies = [
+ "fallible-iterator",
+ "scroll",
+ "uuid",
+]
+
+[[package]]
+name = "pdb-addr2line"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e89a9f2f40b2389ba6da0814c8044bf942bece03dffa1514f84e3b525f4f9a"
+dependencies = [
+ "bitflags 1.3.2",
+ "elsa",
+ "maybe-owned",
+ "pdb",
+ "range-collections",
+ "thiserror",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -698,6 +1416,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "range-collections"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61fdfd79629e2b44a1d34b4d227957174cb858e6b86ee45fad114edbcfc903ab"
+dependencies = [
+ "binary-merge",
+ "inplace-vec-builder",
+ "smallvec",
+]
+
+[[package]]
 name = "rayon"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,11 +1450,31 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall 0.2.16",
+ "thiserror",
 ]
 
 [[package]]
@@ -758,6 +1507,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
+name = "reqwest"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20b9b67e2ca7dd9e9f9285b759de30ff538aab981abaaf7bc9bd90b84a0126c3"
+dependencies = [
+ "async-compression",
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20ec2d3e3fc7a92ced357df9cebd5a10b6fb2aa1ee797bf7e9ce2f17dffc8f59"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,6 +1592,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustix"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,6 +1608,37 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+dependencies = [
+ "base64",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -818,12 +1669,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scroll"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "semsimian"
 version = "0.2.1"
 dependencies = [
  "cargo-llvm-cov",
  "csv",
  "dict",
+ "flamegraph",
  "generator",
  "indicatif",
  "lazy_static",
@@ -883,6 +1751,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "shared_child"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,10 +1779,103 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+
+[[package]]
+name = "socket2"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "str_stack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "symsrv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328d40bbd6972015696ee86709ccc1327a2529816898f2844a62b71e449b1274"
+dependencies = [
+ "bytes",
+ "cab",
+ "dirs",
+ "memmap2",
+ "reqwest",
+ "thiserror",
+ "tokio",
+]
 
 [[package]]
 name = "syn"
@@ -962,6 +1935,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
+dependencies = [
+ "deranged",
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2 0.5.3",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "toml"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,7 +2032,7 @@ version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
- "indexmap",
+ "indexmap 2.0.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -996,10 +2040,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-width"
@@ -1012,6 +2103,35 @@ name = "unindent"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1766d682d402817b5ac4490b3c3002d91dfa0d22812f341609f97b08757359c"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "url"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uuid"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 
 [[package]]
 name = "vcpkg"
@@ -1034,6 +2154,103 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.26",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.26",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "web-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "winapi"
@@ -1065,6 +2282,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
+dependencies = [
+ "windows-targets 0.42.2",
+]
 
 [[package]]
 name = "windows"
@@ -1214,4 +2440,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fac9742fd1ad1bd9643b991319f72dd031016d44b77039a26977eb667141e7"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,5 @@ cargo-llvm-cov = "0.5.19"
 rayon = "1.7.0"
 rusqlite = { version = "0.29.0", features = ["bundled"] }
 
+[features]
+ci = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,7 @@ ci = []
 [profile.release]
 codegen-units = 1
 lto = true
+debug = true
+
+[dev-dependencies]
+flamegraph = "0.6.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ rusqlite = { version = "0.29.0", features = ["bundled"] }
 
 [features]
 ci = []
+
+[profile.release]
+codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ ci = []
 
 [profile.release]
 codegen-units = 1
+lto = true

--- a/python/tests/test_python.py
+++ b/python/tests/test_python.py
@@ -84,7 +84,7 @@ class testSemsimianWithPython(unittest.TestCase):
         self.assertEqual(tsps["best_score"], 5.8496657269155685)
 
     def test_building_closure_ic_map_once(self):
-        load_start = time.time()
+        load_start = round(time.time(), 10)
         subject_terms = {"GO:0005634", "GO:0016020"}
         object_terms = {"GO:0031965", "GO:0005773"}
         predicates = ["rdfs:subClassOf", "BFO:0000050"]
@@ -95,11 +95,11 @@ class testSemsimianWithPython(unittest.TestCase):
             resource_path=self.db,
         )
         _ = semsimian.termset_pairwise_similarity(subject_terms, object_terms)
-        interval_1 = round((time.time() - load_start), 10)
+        interval_1 = round(round(time.time(), 10) - load_start, 10)
         logging.debug(f"Warmup time: {interval_1} sec")
-        second_compare_time = time.time()
+        second_compare_time = round(time.time(), 10)
         _ = semsimian.termset_pairwise_similarity(subject_terms, object_terms)
-        interval_2 = round((time.time() - second_compare_time), 10)
+        interval_2 = round(round(time.time(), 10) - second_compare_time, 10)
         logging.debug(f"Second compare time: {interval_2} sec")
         self.assertGreater(interval_1, interval_2)
 

--- a/python/tests/test_python.py
+++ b/python/tests/test_python.py
@@ -96,11 +96,11 @@ class testSemsimianWithPython(unittest.TestCase):
         load_start = time.time()
         _ = semsimian.termset_pairwise_similarity(subject_terms, object_terms)
         interval_1 = time.time() - load_start
-        logging.debug(f"Warmup time: {interval_1} sec")
+        print(f"Warmup time: {interval_1} sec")
         second_compare_time = time.time()
         _ = semsimian.termset_pairwise_similarity(subject_terms, object_terms)
         interval_2 = time.time() - second_compare_time
-        logging.debug(f"Second compare time: {interval_2} sec")
+        print(f"Second compare time: {interval_2} sec")
         self.assertTrue(interval_1 - interval_2 >= 0)
 
 

--- a/python/tests/test_python.py
+++ b/python/tests/test_python.py
@@ -84,7 +84,6 @@ class testSemsimianWithPython(unittest.TestCase):
         self.assertEqual(tsps["best_score"], 5.8496657269155685)
 
     def test_building_closure_ic_map_once(self):
-        load_start = round(time.time(), 10)
         subject_terms = {"GO:0005634", "GO:0016020"}
         object_terms = {"GO:0031965", "GO:0005773"}
         predicates = ["rdfs:subClassOf", "BFO:0000050"]
@@ -94,6 +93,7 @@ class testSemsimianWithPython(unittest.TestCase):
             pairwise_similarity_attributes=None,
             resource_path=self.db,
         )
+        load_start = round(time.time(), 10)
         _ = semsimian.termset_pairwise_similarity(subject_terms, object_terms)
         interval_1 = round(round(time.time(), 10) - load_start, 10)
         logging.debug(f"Warmup time: {interval_1} sec")

--- a/python/tests/test_python.py
+++ b/python/tests/test_python.py
@@ -93,15 +93,15 @@ class testSemsimianWithPython(unittest.TestCase):
             pairwise_similarity_attributes=None,
             resource_path=self.db,
         )
-        load_start = round(time.time(), 10)
+        load_start = time.time()
         _ = semsimian.termset_pairwise_similarity(subject_terms, object_terms)
-        interval_1 = round(round(time.time(), 10) - load_start, 10)
+        interval_1 = time.time() - load_start
         logging.debug(f"Warmup time: {interval_1} sec")
-        second_compare_time = round(time.time(), 10)
+        second_compare_time = time.time()
         _ = semsimian.termset_pairwise_similarity(subject_terms, object_terms)
-        interval_2 = round(round(time.time(), 10) - second_compare_time, 10)
+        interval_2 = time.time() - second_compare_time
         logging.debug(f"Second compare time: {interval_2} sec")
-        self.assertGreater(interval_1, interval_2)
+        self.assertTrue(interval_1 - interval_2 >= 0)
 
 
 if __name__ == "__main__":

--- a/src/db_query.rs
+++ b/src/db_query.rs
@@ -101,7 +101,7 @@ mod tests {
         let db = &DB_PATH;
         let expected_result: HashMap<String, String> =
             HashMap::from([("GO:0099568".to_string(), "cytoplasmic region".to_string())]);
-        let result = get_labels(db, &vec!["GO:0099568".to_string()]);
+        let result = get_labels(db, &["GO:0099568".to_string()]);
         assert_eq!(result.unwrap(), expected_result);
     }
 }

--- a/src/db_query.rs
+++ b/src/db_query.rs
@@ -42,7 +42,7 @@ pub fn get_entailed_edges_for_predicate_list(
 
 pub fn get_labels(
     path: &str,
-    terms: Vec<TermID>,
+    terms: &Vec<TermID>,
 ) -> Result<HashMap<TermID, String>, rusqlite::Error> {
     let table_name = "statements";
     let joined_terms = format!("'{}'", terms.join("', '"));
@@ -101,7 +101,7 @@ mod tests {
         let db = &DB_PATH;
         let expected_result: HashMap<String, String> =
             HashMap::from([("GO:0099568".to_string(), "cytoplasmic region".to_string())]);
-        let result = get_labels(db, vec!["GO:0099568".to_string()]);
+        let result = get_labels(db, &vec!["GO:0099568".to_string()]);
         assert_eq!(result.unwrap(), expected_result);
     }
 }

--- a/src/db_query.rs
+++ b/src/db_query.rs
@@ -42,7 +42,7 @@ pub fn get_entailed_edges_for_predicate_list(
 
 pub fn get_labels(
     path: &str,
-    terms: &Vec<TermID>,
+    terms: &[TermID],
 ) -> Result<HashMap<TermID, String>, rusqlite::Error> {
     let table_name = "statements";
     let joined_terms = format!("'{}'", terms.join("', '"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -386,25 +386,23 @@ impl RustSemsimian {
         let all_by_all: SimilarityMap =
             self.all_by_all_pairwise_similarity(subject_terms, object_terms, &None, &None);
 
-        let mut all_by_all_object_perspective: SimilarityMap = HashMap::new();
-
+        let mut all_by_all_object_perspective: SimilarityMap =
+            HashMap::with_capacity(all_by_all.len());
         for (key1, value1) in all_by_all.iter() {
             for (key2, value2) in value1.iter() {
-                if !all_by_all_object_perspective.contains_key(key2.as_str()) {
-                    all_by_all_object_perspective.insert(key2.to_owned(), HashMap::new());
-                }
                 all_by_all_object_perspective
-                    .get_mut(key2.as_str())
-                    .unwrap()
+                    .entry(key2.to_owned())
+                    .or_insert_with(HashMap::new)
                     .insert(key1.to_owned(), value2.to_owned());
             }
         }
         let db_path = RESOURCE_PATH.lock().unwrap();
-        let all_terms = subject_terms
-            .union(object_terms)
+        let all_terms: Vec<String> = subject_terms
+            .iter()
+            .chain(object_terms.iter())
             .cloned()
-            .collect::<Vec<String>>();
-        let term_label_map = get_labels(db_path.clone().unwrap().as_str(), all_terms).unwrap();
+            .collect();
+        let term_label_map = get_labels(db_path.clone().unwrap().as_str(), &all_terms).unwrap();
 
         let subject_termset: Vec<BTreeMap<String, BTreeMap<String, String>>> =
             get_termset_vector(subject_terms, &term_label_map);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -953,7 +953,7 @@ mod tests {
     }
 }
 
- #[cfg(not(all(target_env = "github", any(target_os = "linux", target_os = "windows"))))]
+//  #[cfg(not(all(target_env = "github", any(target_os = "linux", target_os = "windows"))))]
  #[cfg(test)]
 mod tests_local {
 
@@ -962,6 +962,7 @@ mod tests_local {
     use std::time::Instant;
 
     #[test]
+    #[cfg_attr(feature = "ci", ignore)]
     fn test_termset_pairwise_similarity_2() {
         let mut db_path = PathBuf::new();
         if let Some(home) = std::env::var_os("HOME") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,7 @@ impl RustSemsimian {
                     && minimum_resnik_threshold.map_or(true, |t| ancestor_information_content > t)
                 {
                     subject_similarities.insert(
-                        object.clone(),
+                        object.to_owned(),
                         (
                             jaccard_similarity,
                             ancestor_information_content,
@@ -225,7 +225,7 @@ impl RustSemsimian {
                 pb.inc(1);
             }
 
-            similarity_map.insert(subject.clone(), subject_similarities);
+            similarity_map.insert(subject.to_owned(), subject_similarities);
         }
 
         pb.finish_with_message("done");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,14 +123,16 @@ impl RustSemsimian {
         {
             let (this_closure_map, this_ic_map) =
                 convert_list_of_tuples_to_hashmap(&self.spo, &self.predicates);
-            self.closure_map.insert(
-                predicate_set_key.clone(),
-                this_closure_map.get(&predicate_set_key).unwrap().clone(),
-            );
-            self.ic_map.insert(
-                predicate_set_key.clone(),
-                this_ic_map.get(&predicate_set_key).unwrap().clone(),
-            );
+
+            if let Some(closure_value) = this_closure_map.get(&predicate_set_key) {
+                self.closure_map
+                    .insert(predicate_set_key.clone(), closure_value.clone());
+            }
+
+            if let Some(ic_value) = this_ic_map.get(&predicate_set_key) {
+                self.ic_map
+                    .insert(predicate_set_key.clone(), ic_value.clone());
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,6 @@ pub struct RustSemsimian {
 }
 
 impl RustSemsimian {
-
     pub fn new(
         spo: Option<Vec<(TermID, Predicate, TermID)>>,
         predicates: Option<Vec<Predicate>>,
@@ -157,7 +156,7 @@ impl RustSemsimian {
         let termset_2 = expand_term_using_closure(term2, &self.closure_map, &self.predicates)
             .into_iter()
             .collect::<HashSet<_>>();
-    
+
         let intersection = termset_1.intersection(&termset_2).count() as f64;
         let union = termset_1.len() as f64 + termset_2.len() as f64 - intersection;
         intersection / union as f64

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,7 @@ impl RustSemsimian {
                     && minimum_resnik_threshold.map_or(true, |t| ancestor_information_content > t)
                 {
                     subject_similarities.insert(
-                        object.to_owned(),
+                        object.clone(),
                         (
                             jaccard_similarity,
                             ancestor_information_content,
@@ -225,7 +225,7 @@ impl RustSemsimian {
                 pb.inc(1);
             }
 
-            similarity_map.insert(subject.to_owned(), subject_similarities);
+            similarity_map.insert(subject.clone(), subject_similarities);
         }
 
         pb.finish_with_message("done");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -600,8 +600,6 @@ mod tests {
     use super::*;
     use crate::test_utils::test_constants::BFO_SPO;
     use crate::{test_utils::test_constants::SPO_FRUITS, RustSemsimian};
-    use std::path::PathBuf;
-    use std::time::Instant;
     use std::{
         collections::HashSet,
         io::{BufRead, BufReader},
@@ -953,9 +951,17 @@ mod tests {
         let expected_result = 5.4154243283740175;
         assert_eq!(result.unwrap(), expected_result);
     }
+}
+
+ #[cfg(not(all(target_env = "github", any(target_os = "linux", target_os = "windows"))))]
+ #[cfg(test)]
+mod tests_local {
+
+    use super::*;
+    use std::path::PathBuf;
+    use std::time::Instant;
 
     #[test]
-    #[cfg(not(all(target_env = "github", any(target_os = "linux", target_os = "windows"))))]
     fn test_termset_pairwise_similarity_2() {
         let mut db_path = PathBuf::new();
         if let Some(home) = std::env::var_os("HOME") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -953,8 +953,8 @@ mod tests {
     }
 }
 
-//  #[cfg(not(all(target_env = "github", any(target_os = "linux", target_os = "windows"))))]
- #[cfg(test)]
+// ! All local tests that need not be run on github actions.
+#[cfg(test)]
 mod tests_local {
 
     use super::*;
@@ -968,9 +968,9 @@ mod tests_local {
         if let Some(home) = std::env::var_os("HOME") {
             db_path.push(home);
             db_path.push(".data/oaklib/phenio.db");
-            } else {
-                panic!("Failed to get home directory");
-            }
+        } else {
+            panic!("Failed to get home directory");
+        }
         // let db = Some("//Users/HHegde/.data/oaklib/phenio.db");
         let db = Some(db_path.to_str().expect("Failed to convert path to string"));
         let predicates: Option<Vec<Predicate>> = Some(vec![
@@ -983,14 +983,20 @@ mod tests_local {
         let mut start_time = Instant::now();
 
         let mut rss = RustSemsimian::new(None, predicates, None, db);
-    
+
         let mut elapsed_time = start_time.elapsed();
-        println!("Time taken for RustSemsimian object generation: {:?}", elapsed_time);
+        println!(
+            "Time taken for RustSemsimian object generation: {:?}",
+            elapsed_time
+        );
         start_time = Instant::now();
 
         rss.update_closure_and_ic_map();
         elapsed_time = start_time.elapsed();
-        println!("Time taken for closure table and ic_map generation: {:?}", elapsed_time);
+        println!(
+            "Time taken for closure table and ic_map generation: {:?}",
+            elapsed_time
+        );
 
         let entity1: HashSet<TermID> = HashSet::from([
             "MP:0010771".to_string(),
@@ -1008,18 +1014,26 @@ mod tests_local {
         start_time = Instant::now();
         let mut _tsps = rss.termset_pairwise_similarity(&entity1, &entity2, &outfile);
         elapsed_time = start_time.elapsed();
-        println!("Time taken for termset_pairwise_similarity: {:?}", elapsed_time);
+        println!(
+            "Time taken for termset_pairwise_similarity: {:?}",
+            elapsed_time
+        );
 
         start_time = Instant::now();
 
         rss.update_closure_and_ic_map();
         elapsed_time = start_time.elapsed();
-        println!("Time taken for second closure and ic_map generation: {:?}", elapsed_time);
+        println!(
+            "Time taken for second closure and ic_map generation: {:?}",
+            elapsed_time
+        );
 
         start_time = Instant::now();
         _tsps = rss.termset_pairwise_similarity(&entity1, &entity2, &outfile);
         elapsed_time = start_time.elapsed();
-        println!("Time taken for second termset_pairwise_similarity: {:?}", elapsed_time);
-        
+        println!(
+            "Time taken for second termset_pairwise_similarity: {:?}",
+            elapsed_time
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -976,7 +976,6 @@ mod tests_local {
             "BFO:0000050".to_string(),
             "UPHENO:0000001".to_string(),
         ]);
-        let outfile = Some("tests/data/output/termset_similarity_output_2.tsv");
         // Start measuring time
         let mut start_time = Instant::now();
 
@@ -1010,7 +1009,7 @@ mod tests_local {
         ]);
 
         start_time = Instant::now();
-        let mut _tsps = rss.termset_pairwise_similarity(&entity1, &entity2, &outfile);
+        let mut _tsps = rss.termset_pairwise_similarity(&entity1, &entity2, &None);
         elapsed_time = start_time.elapsed();
         println!(
             "Time taken for termset_pairwise_similarity: {:?}",
@@ -1027,7 +1026,7 @@ mod tests_local {
         );
 
         start_time = Instant::now();
-        _tsps = rss.termset_pairwise_similarity(&entity1, &entity2, &outfile);
+        _tsps = rss.termset_pairwise_similarity(&entity1, &entity2, &None);
         elapsed_time = start_time.elapsed();
         println!(
             "Time taken for second termset_pairwise_similarity: {:?}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ impl RustSemsimian {
 
         let intersection = termset_1.intersection(&termset_2).count() as f64;
         let union = termset_1.len() as f64 + termset_2.len() as f64 - intersection;
-        intersection / union as f64
+        intersection / union
     }
 
     pub fn resnik_similarity(&self, term1: &str, term2: &str) -> (HashSet<String>, f64) {

--- a/src/similarity.rs
+++ b/src/similarity.rs
@@ -193,10 +193,10 @@ pub fn calculate_cosine_similarity_for_nodes(
             Some(calculate_cosine_similarity_for_embeddings(embed_1, embed_2))
         }
         _ => {
-            if let None = find_embedding_index(embeddings, term1) {
+            if find_embedding_index(embeddings, term1).is_none() {
                 eprintln!("Embedding for term '{}' not found", term1);
             }
-            if let None = find_embedding_index(embeddings, term2) {
+            if find_embedding_index(embeddings, term2).is_none() {
                 eprintln!("Embedding for term '{}' not found", term2);
             }
             None

--- a/src/similarity.rs
+++ b/src/similarity.rs
@@ -6,7 +6,6 @@ use crate::{
     utils::expand_term_using_closure, utils::find_embedding_index, utils::predicate_set_to_key,
 };
 use ordered_float::OrderedFloat;
-// use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
 
 pub fn calculate_semantic_jaccard_similarity(

--- a/src/similarity.rs
+++ b/src/similarity.rs
@@ -64,29 +64,6 @@ pub fn calculate_term_pairwise_information_content(
     // it updates the maximum IC value. Thus, at the end of the iterations,
     // max_resnik_sim_e1_e2 will contain the highest IC score among all the comparisons,
     // representing the best match between entity1 and entity2.
-
-    // let entity1_to_entity2_sum_resnik_sim: f64 = entity1
-    //     .par_iter()
-    //     .map(|e1_term| {
-    //         entity2
-    //             .par_iter()
-    //             .map(|e2_term| {
-    //                 calculate_max_information_content(
-    //                     closure_map,
-    //                     ic_map,
-    //                     e1_term,
-    //                     e2_term,
-    //                     predicates,
-    //                 )
-    //             })
-    //             .max_by(|(_max_ic_ancestors1, ic1), (_max_ic_ancestors2, ic2)| {
-    //                 ic1.partial_cmp(ic2).unwrap()
-    //             })
-    //             .map(|(_max_ic_ancestors, ic)| ic)
-    //             .unwrap_or(0.0)
-    //     })
-    //     .sum();
-
     let mut entity1_to_entity2_sum_resnik_sim = 0.0;
 
     for e1_term in entity1.iter() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -360,29 +360,15 @@ pub fn get_best_score(
     subject_best_matches: &BTreeInBTree,
     object_best_matches: &BTreeInBTree,
 ) -> f64 {
-    let mut max_score = f64::NEG_INFINITY;
+    let max_score = [subject_best_matches, object_best_matches]
+        .iter()
+        .flat_map(|matches| matches.values())
+        .filter_map(|matches| matches.get("score"))
+        .filter_map(|score| score.parse::<f64>().ok())
+        .fold(f64::NEG_INFINITY, |max_score, score_value| {
+            max_score.max(score_value)
+        });
 
-    // Iterate over subject_best_matches
-    for matches in subject_best_matches.values() {
-        if let Some(score) = matches.get("score") {
-            if let Ok(score_value) = score.parse::<f64>() {
-                if score_value > max_score {
-                    max_score = score_value;
-                }
-            }
-        }
-    }
-
-    // Iterate over object_best_matches
-    for matches in object_best_matches.values() {
-        if let Some(score) = matches.get("score") {
-            if let Ok(score_value) = score.parse::<f64>() {
-                if score_value > max_score {
-                    max_score = score_value;
-                }
-            }
-        }
-    }
     max_score
 }
 

--- a/tests/test_termset_pairwise_similarity.rs
+++ b/tests/test_termset_pairwise_similarity.rs
@@ -1,0 +1,41 @@
+use std::{path::PathBuf, collections::HashSet};
+use semsimian::{Predicate, RustSemsimian, TermID};
+
+#[test]
+#[cfg_attr(feature = "ci", ignore)]
+fn test_termset_pairwise_similarity_2() {
+    let mut db_path = PathBuf::new();
+    if let Some(home) = std::env::var_os("HOME") {
+        db_path.push(home);
+        db_path.push(".data/oaklib/phenio.db");
+    } else {
+        panic!("Failed to get home directory");
+    }
+    // let db = Some("//Users/HHegde/.data/oaklib/phenio.db");
+    let db = Some(db_path.to_str().expect("Failed to convert path to string"));
+    let predicates: Option<Vec<Predicate>> = Some(vec![
+        "rdfs:subClassOf".to_string(),
+        "BFO:0000050".to_string(),
+        "UPHENO:0000001".to_string(),
+    ]);
+
+    let mut rss = RustSemsimian::new(None, predicates, None, db);
+    rss.update_closure_and_ic_map();
+
+    let entity1: HashSet<TermID> = HashSet::from([
+        "MP:0010771".to_string(),
+        "MP:0002169".to_string(),
+        "MP:0005391".to_string(),
+        "MP:0005389".to_string(),
+        "MP:0005367".to_string(),
+    ]);
+    let entity2: HashSet<TermID> = HashSet::from([
+        "HP:0004325".to_string(),
+        "HP:0000093".to_string(),
+        "MP:0006144".to_string(),
+    ]);
+
+
+    rss.termset_pairwise_similarity(&entity1, &entity2, &None);
+
+}

--- a/tests/test_termset_pairwise_similarity.rs
+++ b/tests/test_termset_pairwise_similarity.rs
@@ -3,7 +3,7 @@ use semsimian::{Predicate, RustSemsimian, TermID};
 
 #[test]
 #[cfg_attr(feature = "ci", ignore)]
-fn test_termset_pairwise_similarity_2() {
+fn test_termset_pairwise_similarity() {
     let mut db_path = PathBuf::new();
     if let Some(home) = std::env::var_os("HOME") {
         db_path.push(home);

--- a/tests/test_termset_pairwise_similarity.rs
+++ b/tests/test_termset_pairwise_similarity.rs
@@ -1,5 +1,5 @@
-use std::{path::PathBuf, collections::HashSet};
 use semsimian::{Predicate, RustSemsimian, TermID};
+use std::{collections::HashSet, path::PathBuf};
 
 #[test]
 #[cfg_attr(feature = "ci", ignore)]
@@ -35,7 +35,5 @@ fn test_termset_pairwise_similarity() {
         "MP:0006144".to_string(),
     ]);
 
-
     rss.termset_pairwise_similarity(&entity1, &entity2, &None);
-
 }


### PR DESCRIPTION
- [x] Made some code optimization.
- [x] Added phenio test
  - This test is the rust equivalent of Kevin's python code to compare 2 runs. The python code is:

```
import time
from oaklib.selector import get_adapter
​
load_start = time.time()
semsim = get_adapter(f"semsimian:sqlite:obo:phenio")
print(f"Warmup time: {time.time() - load_start} sec")
​
first_compare_time = time.time()
semsim.termset_pairwise_similarity(
            subjects=["MP:0010771","MP:0002169","MP:0005391","MP:0005389","MP:0005367"],
            objects=["HP:0004325","HP:0000093","MP:0006144"],
            predicates=["rdfs:subClassOf", "BFO:0000050", "UPHENO:0000001"],
            labels=False,
        )
print(f"First compare time: {time.time() - first_compare_time} sec")
​
second_compare_time = time.time()
semsim.termset_pairwise_similarity(
            subjects=["MP:0010771","MP:0002169","MP:0005391","MP:0005389","MP:0005367"],
            objects=["HP:0004325","HP:0000093","MP:0006144"],
            predicates=["rdfs:subClassOf", "BFO:0000050", "UPHENO:0000001"],
            labels=False,
        )
print(f"Second compare time: {time.time() - second_compare_time} sec")
```

- [x] Added the ability to `cargo flamegraph` this test.