### PR TITLE
Pregenerate cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,3 +119,21 @@ jobs:
         with:
           command: upload
           args: --skip-existing *
+
+  publish-crate:
+    name: Publish Crate
+    if: '!github.event.prerelease'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Login to Crates.io
+        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
+      - name: Publish
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+  

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1865,7 +1865,7 @@ dependencies = [
 
 [[package]]
 name = "semsimian"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "cargo-llvm-cov",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semsimian"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/benches/association_search_similarity_benchmark.rs
+++ b/benches/association_search_similarity_benchmark.rs
@@ -134,12 +134,24 @@ fn criterion_benchmark(c: &mut Criterion) {
     let search_type: SearchTypeEnum = SearchTypeEnum::Full;
     let include_similarity_object = false;
 
-    let associations = rss.get_or_set_prefix_expansion_cache(
+    let associations = match rss.get_prefix_expansion_cache(
         &assoc_predicate,
         &None,
         &subject_prefixes,
         &search_type,
-    );
+    ) {
+        Some(value) => value, // If the value was found, use it
+        None => {
+            // If the value was not found, set it
+            let value = rss.set_prefix_expansion_cache(
+                &assoc_predicate,
+                &None,
+                &subject_prefixes,
+                &search_type,
+            );
+            value
+        }
+    };
 
     let mut bench_grp = c.benchmark_group("search_bench_group");
     bench_grp.sample_size(10);

--- a/benches/association_search_similarity_benchmark.rs
+++ b/benches/association_search_similarity_benchmark.rs
@@ -143,13 +143,13 @@ fn criterion_benchmark(c: &mut Criterion) {
         Some(value) => value, // If the value was found, use it
         None => {
             // If the value was not found, set it
-            let value = rss.set_prefix_expansion_cache(
+            
+            rss.set_prefix_expansion_cache(
                 &assoc_predicate,
                 &None,
                 &subject_prefixes,
                 &search_type,
-            );
-            value
+            )
         }
     };
 

--- a/python/tests/test_python.py
+++ b/python/tests/test_python.py
@@ -442,6 +442,27 @@ class testSemsimianWithPython(unittest.TestCase):
         )
         pass
 
+    def test_semsimian_cache_creation(self):
+        predicates = ["rdfs:subClassOf", "BFO:0000050"]
+        assoc_predicate = {"biolink:has_nucleus"}
+
+        # assoc_predicate = {"biolink:has_phenotype"}
+        # db_path = os.path.expanduser("~/.data/oaklib/phenio.db")
+
+        semsimian = Semsimian(
+            spo=None,
+            predicates=predicates,
+            pairwise_similarity_attributes=None,
+            resource_path=self.db,
+        )
+        search_type = "flat"
+        semsimian.pregenerate_cache(assoc_predicate, search_type)
+        # semsimian.get_prefix_association_cache() returns a dictionary
+        cache = semsimian.get_prefix_association_cache()
+
+        # Assert that the dictionary is not empty
+        self.assertTrue(bool(cache), "The prefix association cache is empty")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -881,13 +881,13 @@ impl RustSemsimian {
             Some(value) => value, // If the value was found, use it
             None => {
                 // If the value was not found, set it
-                let value = self.set_prefix_expansion_cache(
+                
+                self.set_prefix_expansion_cache(
                     object_closure_predicates,
                     subject_set,
                     subject_prefixes,
                     search_type,
-                );
-                value
+                )
             }
         };
 

--- a/src/similarity.rs
+++ b/src/similarity.rs
@@ -53,8 +53,6 @@ pub fn get_most_recent_common_ancestor_with_score(map: HashMap<String, f64>) -> 
 }
 
 pub fn calculate_term_pairwise_information_content(
-    // closure_map: &HashMap<PredicateSetKey, HashMap<TermID, HashSet<TermID>>>,
-    // ic_map: &HashMap<PredicateSetKey, HashMap<TermID, f64>>,
     rss: &RustSemsimian,
     entity1: &HashSet<TermID>,
     entity2: &HashSet<TermID>,

--- a/tests/test_calculate_similarity_for_association_search.rs
+++ b/tests/test_calculate_similarity_for_association_search.rs
@@ -40,12 +40,24 @@ fn test_calculate_similarity_for_association_search() {
     ]);
     let search_type: SearchTypeEnum = SearchTypeEnum::Full;
 
-    let associations = rss.get_or_set_prefix_expansion_cache(
+    let associations = match rss.get_prefix_expansion_cache(
         &object_closure_predicates,
         &None,
         &subject_prefixes,
         &search_type,
-    );
+    ) {
+        Some(value) => value, // If the value was found, use it
+        None => {
+            // If the value was not found, set it
+            let value = rss.set_prefix_expansion_cache(
+                &object_closure_predicates,
+                &None,
+                &subject_prefixes,
+                &search_type,
+            );
+            value
+        }
+    };
 
     let include_similarity_object = false;
 

--- a/tests/test_calculate_similarity_for_association_search.rs
+++ b/tests/test_calculate_similarity_for_association_search.rs
@@ -49,13 +49,13 @@ fn test_calculate_similarity_for_association_search() {
         Some(value) => value, // If the value was found, use it
         None => {
             // If the value was not found, set it
-            let value = rss.set_prefix_expansion_cache(
+            
+            rss.set_prefix_expansion_cache(
                 &object_closure_predicates,
                 &None,
                 &subject_prefixes,
                 &search_type,
-            );
-            value
+            )
         }
     };
 


### PR DESCRIPTION
This PR:
 - [x] Split get_or_set_prefix_expansion_cache into `get_prefix_expansion_cache` and `set_prefix_expansion_cache`
 - [x] Create a new function `pregenerate_cache` which runs:
   - `self.update_closure_and_ic_map()`
   - `self.set_prefix_expansion_cache()`

This can be called externally form python. itself so that caches for the semsimian object are created in advance for running efficient search.