### PR TITLE
Ancestor labels are now populated

### DIFF
--- a/benches/association_hybrid_search_benchmark.rs
+++ b/benches/association_hybrid_search_benchmark.rs
@@ -128,7 +128,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     ]));
     let search_type: SearchTypeEnum = SearchTypeEnum::Hybrid;
     let limit: Option<usize> = black_box(Some(10));
-    let include_similarity_object = false;
+    let include_similarity_object = true;
     let mut bench_grp = c.benchmark_group("search_bench_group");
     bench_grp.sample_size(10);
     // .measurement_time(Duration::from_secs(300));

--- a/python/tests/test_python.py
+++ b/python/tests/test_python.py
@@ -114,7 +114,7 @@ class testSemsimianWithPython(unittest.TestCase):
             "HP:0002650",
         }
         self.ehlers_danlos_profile = {
-             "HP:0100699",
+            "HP:0100699",
             "HP:0001388",
             "HP:0001382",
             "HP:0001065",
@@ -174,7 +174,7 @@ class testSemsimianWithPython(unittest.TestCase):
             "HP:0012732",
             "HP:0100550",
             "HP:0100645",
-            "HP:0100823"
+            "HP:0100823",
         }
 
     def test_jaccard_similarity(self):

--- a/src/db_query.rs
+++ b/src/db_query.rs
@@ -263,10 +263,7 @@ pub fn get_objects_for_subjects(
     // Iterate over the rows which is of type Rows and populate the HashMap
     for row in rows {
         let (subject, object) = row?;
-        result_map
-            .entry(subject)
-            .or_default()
-            .insert(object);
+        result_map.entry(subject).or_default().insert(object);
     }
 
     Ok(result_map)

--- a/src/db_query.rs
+++ b/src/db_query.rs
@@ -265,7 +265,7 @@ pub fn get_objects_for_subjects(
         let (subject, object) = row?;
         result_map
             .entry(subject)
-            .or_insert_with(HashSet::new)
+            .or_default()
             .insert(object);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -450,7 +450,7 @@ impl RustSemsimian {
             .cloned()
             .collect();
         let all_terms_vec: Vec<String> = all_terms.into_iter().collect();
-        let term_label_map = get_labels(&db_path_str, &all_terms_vec).unwrap();
+        let mut term_label_map = get_labels(&db_path_str, &all_terms_vec).unwrap();
 
         let subject_termset: Vec<BTreeMap<String, BTreeMap<String, String>>> =
             get_termset_vector(subject_terms, &term_label_map);
@@ -461,12 +461,13 @@ impl RustSemsimian {
             .unwrap();
 
         let (subject_best_matches, subject_best_matches_similarity_map) =
-            get_best_matches(&subject_termset, &all_by_all, &term_label_map, metric);
+            get_best_matches(&subject_termset, &all_by_all, &mut term_label_map, metric, &db_path_str);
         let (object_best_matches, object_best_matches_similarity_map) = get_best_matches(
             &object_termset,
             &all_by_all_object_perspective,
-            &term_label_map,
+            &mut term_label_map,
             metric,
+            &db_path_str
         );
         let best_score = get_best_score(&subject_best_matches, &object_best_matches);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,7 +454,7 @@ impl RustSemsimian {
 
         // Expand each term using closure
         for term in &all_terms {
-            let ancestors = expand_term_using_closure(&term, &self.closure_map, &self.predicates)
+            let ancestors = expand_term_using_closure(term, &self.closure_map, &self.predicates)
                 .into_iter()
                 .collect::<HashSet<String>>();
             ancestors_set.extend(ancestors);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,11 +38,11 @@ use utils::{
 };
 
 use crate::similarity::calculate_weighted_term_pairwise_information_content;
+use crate::utils::get_best_score;
 use db_query::get_labels;
 use lazy_static::lazy_static;
-use termset_pairwise_similarity::TermsetPairwiseSimilarity;
 use std::time::Instant;
-use crate::utils::get_best_score;
+use termset_pairwise_similarity::TermsetPairwiseSimilarity;
 
 // change to "pub" because it is easier for testing
 pub type Predicate = String;
@@ -460,14 +460,19 @@ impl RustSemsimian {
             .termset_comparison(subject_terms, object_terms)
             .unwrap();
 
-        let (subject_best_matches, subject_best_matches_similarity_map) =
-            get_best_matches(&subject_termset, &all_by_all, &mut term_label_map, metric, &db_path_str);
+        let (subject_best_matches, subject_best_matches_similarity_map) = get_best_matches(
+            &subject_termset,
+            &all_by_all,
+            &mut term_label_map,
+            metric,
+            &db_path_str,
+        );
         let (object_best_matches, object_best_matches_similarity_map) = get_best_matches(
             &object_termset,
             &all_by_all_object_perspective,
             &mut term_label_map,
             metric,
-            &db_path_str
+            &db_path_str,
         );
         let best_score = get_best_score(&subject_best_matches, &object_best_matches);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,7 +430,7 @@ impl RustSemsimian {
             for (key2, value2) in value1.iter() {
                 all_by_all_object_perspective
                     .entry(key2.to_owned())
-                    .or_insert_with(HashMap::new)
+                    .or_default()
                     .insert(key1.to_owned(), value2.to_owned());
             }
         }
@@ -694,7 +694,7 @@ impl RustSemsimian {
             .map(|prefixes| {
                 get_prefix_association_key(prefixes, object_closure_predicates, search_type)
             })
-            .unwrap_or_else(String::new);
+            .unwrap_or_default();
 
         if self.prefix_expansion_cache.contains_key(&cache_key) {
             println!("Using cache! {:?}", cache_key);
@@ -786,7 +786,7 @@ impl RustSemsimian {
             .map(|prefixes| {
                 get_prefix_association_key(prefixes, object_closure_predicates, search_type)
             })
-            .unwrap_or_else(String::new);
+            .unwrap_or_default();
 
         println!("Generating cache! {:?}", cache_key);
 
@@ -1438,8 +1438,8 @@ mod tests {
         let banana = "banana".to_string();
         let apple = "apple".to_string();
         let pear = "pear".to_string();
-        let outfile = Some("tests/data/output/pairwise_similarity_test_output.tsv");
-        let embeddings_file = Some("tests/data/test_embeddings.tsv");
+        let outfile = "tests/data/output/pairwise_similarity_test_output.tsv";
+        let embeddings_file = "tests/data/test_embeddings.tsv";
 
         let mut subject_terms: HashSet<String> = HashSet::new();
         subject_terms.insert(banana);
@@ -1450,17 +1450,17 @@ mod tests {
         object_terms.insert(pear);
 
         rss.update_closure_and_ic_map();
-        rss.load_embeddings(embeddings_file.unwrap());
+        rss.load_embeddings(embeddings_file);
         rss.all_by_all_pairwise_similarity_with_output(
             &subject_terms,
             &object_terms,
             &Some(0.0),
             &Some(0.0),
-            &outfile,
+            &Some(outfile),
         );
 
         // Read the outfile and count the number of lines
-        let file = File::open(outfile.unwrap()).unwrap();
+        let file = File::open(outfile).unwrap();
         let reader = BufReader::new(file);
 
         let line_count = reader.lines().count();
@@ -1468,7 +1468,7 @@ mod tests {
         assert_eq!(line_count, 3);
 
         // Clean up the temporary file
-        std::fs::remove_file(outfile.unwrap()).expect("Failed to remove file");
+        std::fs::remove_file(outfile).expect("Failed to remove file");
     }
 
     #[test]
@@ -1493,9 +1493,9 @@ mod tests {
     fn test_cosine_using_bfo() {
         let spo = Some(BFO_SPO.clone());
         let mut rss = RustSemsimian::new(spo, None, None, None);
-        let embeddings_file = Some("tests/data/bfo_embeddings.tsv");
+        let embeddings_file = "tests/data/bfo_embeddings.tsv";
 
-        rss.load_embeddings(embeddings_file.unwrap());
+        rss.load_embeddings(embeddings_file);
 
         let cosine_similarity =
             rss.cosine_similarity("BFO:0000040", "BFO:0000002", &rss.embeddings);
@@ -1776,7 +1776,7 @@ mod tests {
         let subject_prefixes: Option<Vec<TermID>> = Some(vec!["GO:".to_string()]);
         let object_terms: HashSet<TermID> = HashSet::from(["GO:0019222".to_string()]);
         let search_type: SearchTypeEnum = SearchTypeEnum::Flat;
-        let limit: Option<usize> = Some(20);
+        let limit: usize = 20;
 
         // Call the function under test
         let result = rss.associations_search(
@@ -1786,7 +1786,7 @@ mod tests {
             &None,
             &subject_prefixes,
             &search_type,
-            limit,
+            Some(limit),
         );
         // assert_eq!({ result.len() }, limit.unwrap());
         //result is a Vec<(f64, obj, String)> I want the count of tuples in the vector that has the f64 value as the first one
@@ -1794,7 +1794,7 @@ mod tests {
         let unique_scores: HashSet<_> =
             result.iter().map(|(score, _, _)| score.to_bits()).collect();
         let count = unique_scores.len();
-        assert!(count <= limit.unwrap());
+        assert!(count <= limit);
         // dbg!(&result);
     }
 
@@ -1834,7 +1834,7 @@ mod tests {
             "HP:0000098".to_string(),
         ]);
         let search_type: SearchTypeEnum = SearchTypeEnum::Full;
-        let limit: Option<usize> = Some(20);
+        let limit: usize = 20;
 
         // Call the function under test
         let result = rss.associations_search(
@@ -1844,12 +1844,12 @@ mod tests {
             &None,
             &subject_prefixes,
             &search_type,
-            limit,
+            Some(limit),
         );
         let unique_scores: HashSet<_> =
             result.iter().map(|(score, _, _)| score.to_bits()).collect();
         let count = unique_scores.len();
-        assert!(count <= limit.unwrap());
+        assert!(count <= limit);
     }
 
     #[test]

--- a/src/termset_pairwise_similarity.rs
+++ b/src/termset_pairwise_similarity.rs
@@ -50,12 +50,18 @@ impl<'a> IntoPy<PyObject> for &'a TermsetPairwiseSimilarity {
         // Create nested dictionaries for subject_best_matches and object_best_matches
         let subject_best_matches_dict = PyDict::new(py);
         subject_best_matches_dict
-            .set_item("similarity", self.subject_best_matches_similarity_map.to_object(py))
+            .set_item(
+                "similarity",
+                self.subject_best_matches_similarity_map.to_object(py),
+            )
             .expect("Failed to set item in subject_best_matches_dict");
 
         let object_best_matches_dict = PyDict::new(py);
         object_best_matches_dict
-            .set_item("similarity", self.object_best_matches_similarity_map.to_object(py))
+            .set_item(
+                "similarity",
+                self.object_best_matches_similarity_map.to_object(py),
+            )
             .expect("Failed to set item in object_best_matches_dict");
 
         // Add your struct fields to the dictionary
@@ -84,4 +90,3 @@ impl<'a> IntoPy<PyObject> for &'a TermsetPairwiseSimilarity {
         tsps_dict.into()
     }
 }
-

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -133,9 +133,9 @@ pub fn convert_list_of_tuples_to_hashmap(
 
         closure_map
             .entry(predicate_set_key.clone())
-            .or_insert_with(HashMap::new)
+            .or_default()
             .entry(String::from(s))
-            .or_insert_with(HashSet::new)
+            .or_default()
             .insert(String::from(o));
 
         progress_bar.inc(1);
@@ -147,7 +147,7 @@ pub fn convert_list_of_tuples_to_hashmap(
 
     ic_map
         .entry(predicate_set_key.clone())
-        .or_insert_with(HashMap::new)
+        .or_default()
         .extend(
             freq_map
                 .iter()
@@ -924,7 +924,7 @@ mod tests {
 
     #[test]
     fn test_get_best_matches() {
-        let db = Some("tests/data/go-nucleus.db");
+        let db = "tests/data/go-nucleus.db";
         // Call the function with the test parameters
         let predicates: Option<Vec<Predicate>> = Some(vec![
             "rdfs:subClassOf".to_string(),
@@ -932,7 +932,7 @@ mod tests {
         ]);
         let subject_terms = HashSet::from(["GO:0005634".to_string(), "GO:0016020".to_string()]);
         let object_terms = HashSet::from(["GO:0031965".to_string(), "GO:0005773".to_string()]);
-        let mut rss = RustSemsimian::new(None, predicates, None, db);
+        let mut rss = RustSemsimian::new(None, predicates, None, Some(db));
         rss.update_closure_and_ic_map();
 
         let all_by_all: SimilarityMap =
@@ -944,7 +944,7 @@ mod tests {
             .cloned()
             .collect();
         let all_terms_vec: Vec<String> = all_terms.into_iter().collect();
-        let mut term_label_map = get_labels(db.unwrap(), &all_terms_vec).unwrap();
+        let mut term_label_map = get_labels(db, &all_terms_vec).unwrap();
 
         let subject_termset: Vec<BTreeMap<String, BTreeMap<String, String>>> =
             get_termset_vector(&subject_terms, &term_label_map);
@@ -952,7 +952,7 @@ mod tests {
         let metric = "ancestor_information_content";
 
         let (best_match, best_matches_similarity_map) =
-            get_best_matches(&subject_termset, &all_by_all, &mut term_label_map, metric, &db.unwrap());
+            get_best_matches(&subject_termset, &all_by_all, &mut term_label_map, metric, db);
 
         let best_match_keys: HashSet<_> = best_match.keys().cloned().collect();
         assert_eq!(best_match_keys, subject_terms);

--- a/tests/test_associations_search.rs
+++ b/tests/test_associations_search.rs
@@ -128,7 +128,7 @@ fn test_large_associations_search() {
         "HP:0002650".to_string(),
     ]);
     let search_type_full: SearchTypeEnum = SearchTypeEnum::Full;
-    let limit: Option<usize> = Some(10);
+    let limit: usize = 10;
     
     // Start timing before the function call
     let start = Instant::now();
@@ -141,7 +141,7 @@ fn test_large_associations_search() {
         &None,
         &subject_prefixes,
         &search_type_full,
-        limit,
+        Some(limit),
     );
 
     // Stop timing after the function call
@@ -159,12 +159,12 @@ fn test_large_associations_search() {
         &None,
         &subject_prefixes,
         &search_type_full,
-        limit,
+        Some(limit),
     );
     // Stop timing after the function call
     let duration = start.elapsed();
 
-    assert_eq!({ result.len() }, limit.unwrap());
+    assert_eq!({ result.len() }, limit);
 
     // dbg!(&result);
     // print the time:
@@ -299,7 +299,7 @@ fn test_flat_vs_full_search() {
 
     let search_type_flat: SearchTypeEnum = SearchTypeEnum::Flat;
     let search_type_full: SearchTypeEnum = SearchTypeEnum::Full;
-    let limit: Option<usize> = Some(10);
+    let limit: usize = 10;
 
     // Call the function under test
     let result_1 = rss.associations_search(
@@ -309,7 +309,7 @@ fn test_flat_vs_full_search() {
         &None,
         &subject_prefixes,
         &search_type_full,
-        limit,
+        Some(limit),
     );
     // Call the function under test
     let result_2 = rss.associations_search(
@@ -319,7 +319,7 @@ fn test_flat_vs_full_search() {
         &None,
         &subject_prefixes,
         &search_type_flat,
-        limit,
+        Some(limit),
     );
 
     dbg!(&result_1.len());
@@ -377,8 +377,8 @@ fn test_flat_vs_full_search() {
     // dbg!(&result_2_unique);
     // dbg!(&result_1_matches);
     // dbg!(&result_2_matches);
-    assert_eq!({ result_1.len() }, limit.unwrap());
-    assert_eq!({ result_2.len() }, limit.unwrap());
+    assert_eq!({ result_1.len() }, limit);
+    assert_eq!({ result_2.len() }, limit);
     assert_eq!(match_percentage, 100.0);
     assert!(result_1_unique.is_empty(), "result_1_unique is not empty");
     assert!(result_2_unique.is_empty(), "result_2_unique is not empty");
@@ -511,7 +511,7 @@ fn test_flat_vs_hybrid_search() {
 
     let search_type_flat: SearchTypeEnum = SearchTypeEnum::Flat;
     let search_type_hybrid: SearchTypeEnum = SearchTypeEnum::Hybrid;
-    let limit: Option<usize> = Some(10);
+    let limit: usize = 10;
 
     // Call the function under test
     let result_1 = rss.associations_search(
@@ -521,7 +521,7 @@ fn test_flat_vs_hybrid_search() {
         &None,
         &subject_prefixes,
         &search_type_flat,
-        limit,
+        Some(limit),
     );
     // Call the function under test
     let result_2 = rss.associations_search(
@@ -531,7 +531,7 @@ fn test_flat_vs_hybrid_search() {
         &None,
         &subject_prefixes,
         &search_type_hybrid,
-        limit,
+        Some(limit),
     );
 
     dbg!(&result_1.len());
@@ -589,8 +589,8 @@ fn test_flat_vs_hybrid_search() {
     // dbg!(&result_2_unique);
     // dbg!(&result_1_matches);
     // dbg!(&result_2_matches);
-    assert_eq!({ result_1.len() }, limit.unwrap());
-    assert_eq!({ result_2.len() }, limit.unwrap());
+    assert_eq!({ result_1.len() }, limit);
+    assert_eq!({ result_2.len() }, limit);
     assert_eq!(match_percentage, 100.0);
     assert!(result_1_unique.is_empty(), "result_1_unique is not empty");
     assert!(result_2_unique.is_empty(), "result_2_unique is not empty");
@@ -723,7 +723,7 @@ fn test_full_vs_hybrid_search() {
 
     let search_type_full: SearchTypeEnum = SearchTypeEnum::Full;
     let search_type_hybrid: SearchTypeEnum = SearchTypeEnum::Hybrid;
-    let limit: Option<usize> = Some(100);
+    let limit: usize = 100;
 
     // Call the function under test
     let result_1 = rss.associations_search(
@@ -733,7 +733,7 @@ fn test_full_vs_hybrid_search() {
         &None,
         &subject_prefixes,
         &search_type_full,
-        limit,
+        Some(limit),
     );
     // Call the function under test
     let result_2 = rss.associations_search(
@@ -743,7 +743,7 @@ fn test_full_vs_hybrid_search() {
         &None,
         &subject_prefixes,
         &search_type_hybrid,
-        limit,
+        Some(limit),
     );
 
     dbg!(&result_1.len());
@@ -804,8 +804,8 @@ fn test_full_vs_hybrid_search() {
     dbg!(&result_2_unique);
     dbg!(&result_1_matches);
     dbg!(&result_2_matches);
-    assert_eq!({ result_1.len() }, limit.unwrap());
-    assert_eq!({ result_2.len() }, limit.unwrap());
+    assert_eq!({ result_1.len() }, limit);
+    assert_eq!({ result_2.len() }, limit);
     assert_eq!(match_percentage, 100.0);
     assert!(result_1_unique.is_empty(), "result_1_unique is not empty");
     assert!(result_2_unique.is_empty(), "result_2_unique is not empty");

--- a/tests/test_associations_search.rs
+++ b/tests/test_associations_search.rs
@@ -129,7 +129,7 @@ fn test_large_associations_search() {
     ]);
     let search_type_full: SearchTypeEnum = SearchTypeEnum::Full;
     let limit: usize = 10;
-    
+
     // Start timing before the function call
     let start = Instant::now();
 

--- a/tests/test_termset_pairwise_similarity.rs
+++ b/tests/test_termset_pairwise_similarity.rs
@@ -6,13 +6,12 @@ use std::{collections::HashSet, path::PathBuf};
 #[cfg_attr(feature = "ci", ignore)]
 fn test_large_termset_pairwise_similarity() {
     let mut db_path = PathBuf::new();
-    if let Some(home) = std::env::var_os("HOME") {
-        db_path.push(home);
-        db_path.push(".data/oaklib/phenio.db");
-    } else {
-        panic!("Failed to get home directory");
-    }
-
+        if let Some(home) = std::env::var_os("HOME") {
+            db_path.push(home);
+            db_path.push(".data/oaklib/phenio.db");
+        } else {
+            panic!("Failed to get home directory");
+        }
     let db = Some(db_path.to_str().expect("Failed to convert path to string"));
     let predicates: Option<Vec<Predicate>> = Some(vec![
         "rdfs:subClassOf".to_string(),
@@ -131,4 +130,52 @@ fn test_large_termset_pairwise_similarity() {
 
     let result = rss.termset_pairwise_similarity(&entity1, &entity2);
     dbg!(&result);
+    
+}
+
+#[test]
+// #[ignore]
+#[cfg_attr(feature = "ci", ignore)]
+fn test_ancestor_label_presence() {
+    let mut db_path = PathBuf::new();
+        if let Some(home) = std::env::var_os("HOME") {
+            db_path.push(home);
+            db_path.push(".data/oaklib/phenio.db");
+        } else {
+            panic!("Failed to get home directory");
+        }
+    let db = Some(db_path.to_str().expect("Failed to convert path to string"));
+    let predicates: Option<Vec<Predicate>> = Some(vec![
+        "rdfs:subClassOf".to_string(),
+        "BFO:0000050".to_string(),
+        "UPHENO:0000001".to_string(),
+    ]);
+
+    let mut rss = RustSemsimian::new(None, predicates, None, db);
+    rss.update_closure_and_ic_map();
+
+    let entity1: HashSet<TermID> = HashSet::from([
+        "MP:0010771".to_string(),
+        "MP:0002169".to_string(),
+        "MP:0005391".to_string(),
+        "MP:0005389".to_string(),
+        "MP:0005367".to_string(),
+    ]);
+    let entity2: HashSet<TermID> = HashSet::from([
+        "HP:0004325".to_string(),
+        "HP:0000093".to_string(),
+        "MP:0006144".to_string(),
+    ]);
+    let result = rss.termset_pairwise_similarity(&entity1, &entity2);
+    
+    dbg!(&result);
+    for (_, value) in &result.subject_best_matches_similarity_map {
+        assert!(value.get("ancestor_label").is_some(), "Ancestor label in subject_best_matches_similarity_map should not be None");
+        assert!(!value.get("ancestor_label").as_ref().unwrap().is_empty(), "Ancestor label in subject_best_matches_similarity_map should not be empty");
+    }
+
+    for (_, value) in &result.object_best_matches_similarity_map {
+        assert!(value.get("ancestor_label").is_some(), "Ancestor label in object_best_matches_similarity_map should not be None");
+        assert!(!value.get("ancestor_label").as_ref().unwrap().is_empty(), "Ancestor label in object_best_matches_similarity_map should not be empty");
+    }
 }

--- a/tests/test_termset_pairwise_similarity.rs
+++ b/tests/test_termset_pairwise_similarity.rs
@@ -134,7 +134,7 @@ fn test_large_termset_pairwise_similarity() {
 }
 
 #[test]
-// #[ignore]
+#[ignore]
 #[cfg_attr(feature = "ci", ignore)]
 fn test_ancestor_label_presence() {
     let mut db_path = PathBuf::new();

--- a/tests/test_termset_pairwise_similarity.rs
+++ b/tests/test_termset_pairwise_similarity.rs
@@ -6,12 +6,12 @@ use std::{collections::HashSet, path::PathBuf};
 #[cfg_attr(feature = "ci", ignore)]
 fn test_large_termset_pairwise_similarity() {
     let mut db_path = PathBuf::new();
-        if let Some(home) = std::env::var_os("HOME") {
-            db_path.push(home);
-            db_path.push(".data/oaklib/phenio.db");
-        } else {
-            panic!("Failed to get home directory");
-        }
+    if let Some(home) = std::env::var_os("HOME") {
+        db_path.push(home);
+        db_path.push(".data/oaklib/phenio.db");
+    } else {
+        panic!("Failed to get home directory");
+    }
     let db = Some(db_path.to_str().expect("Failed to convert path to string"));
     let predicates: Option<Vec<Predicate>> = Some(vec![
         "rdfs:subClassOf".to_string(),
@@ -130,7 +130,6 @@ fn test_large_termset_pairwise_similarity() {
 
     let result = rss.termset_pairwise_similarity(&entity1, &entity2);
     dbg!(&result);
-    
 }
 
 #[test]
@@ -138,12 +137,12 @@ fn test_large_termset_pairwise_similarity() {
 #[cfg_attr(feature = "ci", ignore)]
 fn test_ancestor_label_presence() {
     let mut db_path = PathBuf::new();
-        if let Some(home) = std::env::var_os("HOME") {
-            db_path.push(home);
-            db_path.push(".data/oaklib/phenio.db");
-        } else {
-            panic!("Failed to get home directory");
-        }
+    if let Some(home) = std::env::var_os("HOME") {
+        db_path.push(home);
+        db_path.push(".data/oaklib/phenio.db");
+    } else {
+        panic!("Failed to get home directory");
+    }
     let db = Some(db_path.to_str().expect("Failed to convert path to string"));
     let predicates: Option<Vec<Predicate>> = Some(vec![
         "rdfs:subClassOf".to_string(),
@@ -167,15 +166,27 @@ fn test_ancestor_label_presence() {
         "MP:0006144".to_string(),
     ]);
     let result = rss.termset_pairwise_similarity(&entity1, &entity2);
-    
+
     dbg!(&result);
     for value in result.subject_best_matches_similarity_map.values() {
-        assert!(value.get("ancestor_label").is_some(), "Ancestor label in subject_best_matches_similarity_map should not be None");
-        assert!(!value.get("ancestor_label").as_ref().unwrap().is_empty(), "Ancestor label in subject_best_matches_similarity_map should not be empty");
+        assert!(
+            value.get("ancestor_label").is_some(),
+            "Ancestor label in subject_best_matches_similarity_map should not be None"
+        );
+        assert!(
+            !value.get("ancestor_label").as_ref().unwrap().is_empty(),
+            "Ancestor label in subject_best_matches_similarity_map should not be empty"
+        );
     }
 
     for value in result.object_best_matches_similarity_map.values() {
-        assert!(value.get("ancestor_label").is_some(), "Ancestor label in object_best_matches_similarity_map should not be None");
-        assert!(!value.get("ancestor_label").as_ref().unwrap().is_empty(), "Ancestor label in object_best_matches_similarity_map should not be empty");
+        assert!(
+            value.get("ancestor_label").is_some(),
+            "Ancestor label in object_best_matches_similarity_map should not be None"
+        );
+        assert!(
+            !value.get("ancestor_label").as_ref().unwrap().is_empty(),
+            "Ancestor label in object_best_matches_similarity_map should not be empty"
+        );
     }
 }

--- a/tests/test_termset_pairwise_similarity.rs
+++ b/tests/test_termset_pairwise_similarity.rs
@@ -169,12 +169,12 @@ fn test_ancestor_label_presence() {
     let result = rss.termset_pairwise_similarity(&entity1, &entity2);
     
     dbg!(&result);
-    for (_, value) in &result.subject_best_matches_similarity_map {
+    for value in result.subject_best_matches_similarity_map.values() {
         assert!(value.get("ancestor_label").is_some(), "Ancestor label in subject_best_matches_similarity_map should not be None");
         assert!(!value.get("ancestor_label").as_ref().unwrap().is_empty(), "Ancestor label in subject_best_matches_similarity_map should not be empty");
     }
 
-    for (_, value) in &result.object_best_matches_similarity_map {
+    for value in result.object_best_matches_similarity_map.values() {
         assert!(value.get("ancestor_label").is_some(), "Ancestor label in object_best_matches_similarity_map should not be None");
         assert!(!value.get("ancestor_label").as_ref().unwrap().is_empty(), "Ancestor label in object_best_matches_similarity_map should not be empty");
     }

--- a/tests/test_termset_pairwise_similarity.rs
+++ b/tests/test_termset_pairwise_similarity.rs
@@ -133,7 +133,7 @@ fn test_large_termset_pairwise_similarity() {
 }
 
 #[test]
-#[ignore]
+// #[ignore]
 #[cfg_attr(feature = "ci", ignore)]
 fn test_ancestor_label_presence() {
     let mut db_path = PathBuf::new();


### PR DESCRIPTION
Fixes #108 

As the code sits now, the labels of CURIEs that are **ONLY** in either the `subject_terms` or `object_terms` are retrieved from the resource. Therefore, for any  `ancestor_id` that is not in either term lists, the label is never retrieved. I added a test to confirm that `ancestor_label` is present for all `ancestor_id`s.  If not, a default is entered (`LABEL NOT IN RESOURCE`) which should rarely be the case. 

This PR fixes that. Sorry @kevinschaper for taking this long to resolve this.