### PR TITLE
chore: update supported python versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           target: x86_64
           command: build
-          args: --release --out dist -i 3.7 3.8 3.9 '3.10' '3.11'
+          args: --release --out dist -i 3.8 3.9 '3.10' '3.11' '3.12'
       - name: Install built x86_64 wheel
         run: |
           pip install semsimian --no-index --find-links dist --force-reinstall
@@ -29,7 +29,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          args: --release --universal2 --out dist -i 3.7 3.8 3.9 '3.10' '3.11'
+          args: --release --universal2 --out dist -i 3.8 3.9 '3.10' '3.11' '3.12'
       - name: Install built universal2 wheel
         run: |
           pip install semsimian --no-index --find-links dist --force-reinstall
@@ -58,7 +58,7 @@ jobs:
         rust-toolchain: stable
         target: ${{ matrix.target }}
         manylinux: auto
-        args: --release --out dist -i 3.7 3.8 3.9 '3.10' '3.11'
+        args: --release --out dist -i 3.8 3.9 '3.10' '3.11' '3.12'
     - name: Install built wheel
       if: matrix.target == 'x86_64'
       run: |
@@ -89,7 +89,7 @@ jobs:
       with:
         rust-toolchain: stable
         target: ${{ matrix.target }}
-        args: --release --out dist -i 3.7 3.8 3.9 '3.10' '3.11'
+        args: --release --out dist -i 3.8 3.9 '3.10' '3.11' '3.12'
     - name: Install built wheel
       if: matrix.target == 'x86_64'
       run: |

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ Wheels are prepared for the following environments and architectures:
 
 | OS      | Architectures                                                                            | Python Versions           |
 |---------|------------------------------------------------------------------------------------------|---------------------------|
-| Linux   | x86_64, x86_64-unknown-linux-musl, aarch64-unknown-linux-gnu, aarch64-unknown-linux-musl | 3.7, 3.8, 3.9, 3.10, 3.11 |
-| MacOS   | x86_64, universal2                                                                       | 3.7, 3.8, 3.9, 3.10, 3.11 |
-| Windows | x86_64                                                                                   | 3.7, 3.8, 3.9, 3.10, 3.11 |
+| Linux   | x86_64, x86_64-unknown-linux-musl, aarch64-unknown-linux-gnu, aarch64-unknown-linux-musl | 3.8, 3.9, 3.10, 3.11, 3.12 |
+| MacOS   | x86_64, universal2                                                                       | 3.8, 3.9, 3.10, 3.11, 3.12 |
+| Windows | x86_64                                                                                   | 3.8, 3.9, 3.10, 3.11, 3.12 |
 
 ## Troubleshooting
 


### PR DESCRIPTION
Replace support for unsupported Python version 3.7 (reached end-of-life) with latest version 3.12.