### PR TITLE
add an alternate association search function that gets passed a cache that it deosn't own

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1008,7 +1008,7 @@ impl RustSemsimian {
         subject_prefixes: &Option<Vec<TermID>>,
         search_type: &SearchTypeEnum,
     ) -> HashMap<String, HashSet<String>> {
-        let cache_key = subject_prefixes
+        let _cache_key = subject_prefixes
             .as_ref()
             .map(|prefixes| {
                 get_prefix_association_key(prefixes, object_closure_predicates, search_type)
@@ -1026,12 +1026,12 @@ impl RustSemsimian {
     
     // This function is used to search associations with an externally provided cache.
     pub fn associations_search_with_cache(
-        &self,
-        object_closure_predicates: &HashSet<TermID>,
+        &mut self,
+        _object_closure_predicates: &HashSet<TermID>,
         object_set: &HashSet<TermID>,
         include_similarity_object: bool,
-        subject_set: &Option<HashSet<TermID>>,
-        subject_prefixes: &Option<Vec<TermID>>,
+        _subject_set: &Option<HashSet<TermID>>,
+        _subject_prefixes: &Option<Vec<TermID>>,
         search_type: &SearchTypeEnum,
         score_metric: &MetricEnum,
         limit: Option<usize>,

--- a/tests/test_associations_search.rs
+++ b/tests/test_associations_search.rs
@@ -845,10 +845,10 @@ fn test_associations_search_with_cache() {
         db_path.push(home);
         db_path.push(".data/oaklib/phenio.db");
     } else {
-        panic\!("Failed to get home directory");
+        panic!("Failed to get home directory");
     }
 
-    let predicates: Option<Vec<Predicate>> = Some(vec\![
+    let predicates: Option<Vec<Predicate>> = Some(vec![
         "rdfs:subClassOf".to_string(),
         "BFO:0000050".to_string(),
         "UPHENO:0000001".to_string(),
@@ -861,7 +861,7 @@ fn test_associations_search_with_cache() {
 
     // Define input parameters for the function
     let assoc_predicate: HashSet<TermID> = HashSet::from(["biolink:has_phenotype".to_string()]);
-    let subject_prefixes: Option<Vec<TermID>> = Some(vec\!["MONDO:".to_string()]);
+    let subject_prefixes: Option<Vec<TermID>> = Some(vec!["MONDO:".to_string()]);
 
     // Create a smaller test set for speed
     let object_terms: HashSet<TermID> = HashSet::from([
@@ -917,8 +917,7 @@ fn test_associations_search_with_cache() {
     let result_with_cache_ids: Vec<&String> = result_with_cache.iter().map(|(_, _, id)| id).collect();
     
     // Results should be identical
-    assert_eq\!(result_standard_ids, result_with_cache_ids, "Results differ between standard and with-cache methods");
-    assert_eq\!(result_standard.len(), limit);
-    assert_eq\!(result_with_cache.len(), limit);
+    assert_eq!(result_standard_ids, result_with_cache_ids, "Results differ between standard and with-cache methods");
+    assert_eq!(result_standard.len(), limit);
+    assert_eq!(result_with_cache.len(), limit);
 }
-EOL < /dev/null


### PR DESCRIPTION
For semsimian-server running as part of monarch's api, right now we have to pay for twice as much ram as we actually need, because we have one cache for compare (reused across api workers) and one cache for search that is used only within one worker. 